### PR TITLE
refactor: cleanup dependencies docs and standardize exports

### DIFF
--- a/.agent/config.md
+++ b/.agent/config.md
@@ -1,17 +1,16 @@
-# Agent Configuration -eo_lib
+# Agent Configuration - agent_sigpesq
 
 ## 🏗 Technical Stack
 - **Language**: Python 3.12+
 - **Build System**: Hatchling (see `pyproject.toml`)
-- **Main Dependencies**: SQLAlchemy 2.0+
+- **Main Dependencies**: Selenium, Pydantic
 - **Test Framework**: Pytest
 - **Linting Tools**: Black, Flake8, isort
 
 ## 📂 Project Structure Map
-- `src/eo_lib/domain/`: `BaseEntity` and core abstractions.
-- `src/eo_lib/infrastructure/`: Repository strategies (SQL, JSON, Memory).
-- `src/eo_lib/services/`: `GenericService`.
-- `src/eo_lib/controllers/`: `GenericController`.
+- `src/agent_sigpesq/core/`: Application core logic.
+- `src/agent_sigpesq/services/`: Service layer.
+- `src/agent_sigpesq/strategies/`: Strategy pattern implementations.
 - `tests/`: TDD suite mimicking the `src/` structure.
 - `docs/`: Full project documentation (SRS, SDD, Backlog, Milestones).
 
@@ -26,7 +25,6 @@
 ## 📦 Distribution Standards
 - Adhere to SemVer 2.0.0.
 - Minimal external dependencies.
-- Unified Domain/ORM models (DRY).
 
 ## 📝 Governance Templates
 Use these patterns for all new issues:

--- a/src/agent_sigpesq/core/__init__.py
+++ b/src/agent_sigpesq/core/__init__.py
@@ -4,3 +4,7 @@ Core module for Agent Sigpesq.
 Contains fundamental abstractions and factories used throughout the library, 
 including the `BaseAgent` and `BrowserFactory`.
 """
+from .base_agent import BaseAgent
+from .browser_factory import BrowserFactory
+
+__all__ = ["BaseAgent", "BrowserFactory"]

--- a/src/agent_sigpesq/services/__init__.py
+++ b/src/agent_sigpesq/services/__init__.py
@@ -4,3 +4,6 @@ Services module for Agent Sigpesq.
 Contains the main service implementations that orchestrate business logic, 
 such as the `SigpesqReportService`.
 """
+from .reports_service import SigpesqReportService
+
+__all__ = ["SigpesqReportService"]


### PR DESCRIPTION
## Description
This PR addresses issue #1 by:
1.  Removing references to unused libraries (`SQLAlchemy`, `eo_lib`) from `.agent/config.md`.
2.  Configuring `__init__.py` files in `src/agent_sigpesq/core` and `src/agent_sigpesq/services` to export public classes (`BaseAgent`, `BrowserFactory`, `SigpesqReportService`), simplifying imports.

## Verification
- Verified manually that `agent_sigpesq` packages are importable and expose the expected classes.
- Verified configuration documentation matches `pyproject.toml` dependencies.

Closes #1
