### PR TITLE
feat: Implement CLI commands for partial report downloads

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -1,17 +1,49 @@
 import asyncio
+import argparse
+import sys
+from agent_sigpesq.services.reports_service import SigpesqReportService
+from agent_sigpesq.strategies import (
+    ResearchGroupsDownloadStrategy,
+    ProjectsDownloadStrategy,
+    AdvisorshipsDownloadStrategy
+)
 
 async def main():
+    parser = argparse.ArgumentParser(description="Sigpesq Report Downloader Agent")
+    subparsers = parser.add_subparsers(dest="command", help="Command to execute")
+
+    # Subcommands
+    subparsers.add_parser("download-all", help="Download all reports (default)")
+    subparsers.add_parser("download-groups", help="Download only Research Groups reports")
+    subparsers.add_parser("download-projects", help="Download only Research Projects reports")
+    subparsers.add_parser("download-advisorships", help="Download only Advisorships reports")
+
+    args = parser.parse_args()
+
+    strategies = None
+    if args.command == "download-groups":
+        strategies = [ResearchGroupsDownloadStrategy()]
+        print("Configuration: Downloading Research Groups only.")
+    elif args.command == "download-projects":
+        strategies = [ProjectsDownloadStrategy()]
+        print("Configuration: Downloading Research Projects only.")
+    elif args.command == "download-advisorships":
+        strategies = [AdvisorshipsDownloadStrategy()]
+        print("Configuration: Downloading Advisorships only.")
+    else:
+        print("Configuration: Downloading ALL reports.")
+
     print("Starting Sigpesq Report Download Job...")
-    from agent_sigpesq.services.reports_service import SigpesqReportService
     
     # Run in headless mode and save reports to 'reports' folder
-    service = SigpesqReportService(headless=True, download_dir="reports")
+    service = SigpesqReportService(headless=True, download_dir="reports", strategies=strategies)
     success = await service.run()
     
     if success:
         print("Report download job completed successfully!")
     else:
         print("Report download job failed.")
+        sys.exit(1)
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -31,6 +31,15 @@ The system automates the login process and downloads three categories of researc
 - System verifies successful login before proceeding
 - System provides error messages for failed authentication
 
+#### FR-1.1: CLI Strategy Selection
+**Priority**: Medium
+**Description**: The system shall provide CLI commands to execute specific download strategies individually (Groups, Projects, Advisorships).
+
+**Acceptance Criteria**:
+- System accepts command line arguments to select strategy
+- System supports `download-groups`, `download-projects`, `download-advisorships` commands
+- System supports default `download-all` behavior
+
 #### FR-2: Research Groups Report Download
 **Priority**: High  
 **Description**: The system shall download the "Grupos de Pesquisa" (Research Groups) report.

--- a/docs/sdd.md
+++ b/docs/sdd.md
@@ -32,6 +32,13 @@ The system follows a modular architecture based on MVC and SOLID principles.
 - Credentials are read from environment variables (.env).
 - Reports are saved to a local `reports/` folder.
 
+### 3.4 CLI Design
+The `agent.py` entry point will be refactored to use `argparse` to support subcommands:
+- `download-all`: Executes all configured strategies (default).
+- `download-groups`: Executes only `ResearchGroupsDownloadStrategy`.
+- `download-projects`: Executes only `ProjectsDownloadStrategy`.
+- `download-advisorships`: Executes only `AdvisorshipsDownloadStrategy`.
+
 ## 4. User Interface Design
 Automated interaction via Selenium. The report service will navigate to the reports list and click expansion/download buttons sequentially.
 

--- a/src/agent_sigpesq/services/reports_service.py
+++ b/src/agent_sigpesq/services/reports_service.py
@@ -46,13 +46,15 @@ class SigpesqReportService(BaseAgent[None, bool]):
         strategies (List[ReportDownloadStrategy]): List of download strategies to execute.
     """
 
-    def __init__(self, headless: bool = True, download_dir: str = "reports"):
+    def __init__(self, headless: bool = True, download_dir: str = "reports", strategies: List[ReportDownloadStrategy] = None):
         """
         Initializes the SigpesqReportService.
 
         Args:
             headless (bool): Whether to run the browser in headless mode. Defaults to True.
             download_dir (str): Directory where reports will be saved. Defaults to "reports".
+            strategies (List[ReportDownloadStrategy], optional): List of specific strategies to execute. 
+                                                                 If None, executes all default strategies.
         """
         self.username = os.getenv("SIGPESQ_USER")
         self.password = os.getenv("SIGPESQ_PASSWORD")
@@ -62,8 +64,11 @@ class SigpesqReportService(BaseAgent[None, bool]):
         self.download_dir = download_dir
         self.driver = None
         
-        # Initialize strategies in the order requested by user
-        self.strategies: List[ReportDownloadStrategy] = [
+        # Initialize strategies
+        if strategies:
+            self.strategies = strategies
+        else:
+            self.strategies = [
             ResearchGroupsDownloadStrategy(),
             ProjectsDownloadStrategy(),
             AdvisorshipsDownloadStrategy()


### PR DESCRIPTION
Closes #12. 

## Summary
Implements CLI commands to execute download strategies individually.

## Changes
- Modified `SigpesqReportService` to accept strategies.
- Updated `agent.py` to use `argparse`.
- Added commands: `download-groups`, `download-projects`, `download-advisorships`.

## Verification
Verified via manual execution of commands (CLI parsing confirmed).
