### PR TITLE
test: Implement unit tests for strategies

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -133,6 +133,7 @@ The system automates the login process and downloads three categories of researc
 - Factory Pattern for object creation
 - Clear separation of concerns (MVC)
 - Comprehensive documentation (IEEE SDD)
+- **Test Coverage**: Each strategy execution flow must be covered by unit tests mocking the WebDriver.
 
 #### NFR-4: Usability
 **Priority**: Medium  

--- a/docs/sdd.md
+++ b/docs/sdd.md
@@ -47,3 +47,9 @@ Automated interaction via Selenium. The report service will navigate to the repo
 - **Strategy/Template Method**: Used in BaseAgent.
 - **SOLID**: Single Responsibility (ReportService focuses on document generation).
 - **Factory**: BrowserFactory for WebDriver configuration.
+
+## 6. Test Strategy
+Unit tests will be implemented for each strategy using `unittest.mock` to simulate `selenium.webdriver` behavior.
+- **Mocking**: `WebDriver`, `WebElement`, `WebDriverWait`.
+- **Scope**: Verify that `download()` calls expected driver methods (find_element, click, execute_script).
+

--- a/src/agent_sigpesq/core/browser_factory.py
+++ b/src/agent_sigpesq/core/browser_factory.py
@@ -8,7 +8,6 @@ and download settings.
 
 import os
 from selenium import webdriver
-from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 
 class BrowserFactory:

--- a/tests/test_advisorships_strategy.py
+++ b/tests/test_advisorships_strategy.py
@@ -1,0 +1,84 @@
+import unittest
+from unittest.mock import MagicMock, patch, call
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from agent_sigpesq.strategies.advisorships_strategy import AdvisorshipsDownloadStrategy
+
+class TestAdvisorshipsDownloadStrategy(unittest.TestCase):
+    def setUp(self):
+        self.strategy = AdvisorshipsDownloadStrategy()
+        self.mock_driver = MagicMock()
+        self.reports_dir = "/tmp/reports"
+
+    @patch('agent_sigpesq.strategies.advisorships_strategy.WebDriverWait')
+    @patch('agent_sigpesq.strategies.advisorships_strategy.Select')
+    @patch('agent_sigpesq.strategies.advisorships_strategy.AdvisorshipsDownloadStrategy._wait_and_move_file')
+    def test_download_success(self, mock_wait_and_move, MockSelect, MockWebDriverWait):
+        # Setup mocks
+        mock_wait_instance = MockWebDriverWait.return_value
+        mock_element = MagicMock()
+        mock_element.tag_name = "select"  # Critical for Select class check
+        mock_wait_instance.until.return_value = mock_element
+        
+        # Setup mocked Select
+        mock_select_instance = MockSelect.return_value
+        # Mock options: e.g., 2024 and 2025
+        option1 = MagicMock()
+        option1.get_attribute.return_value = "2024"
+        option2 = MagicMock()
+        option2.get_attribute.return_value = "2025"
+        mock_select_instance.options = [option1, option2]
+        
+        mock_wait_and_move.return_value = True
+
+        # Execute
+        result = self.strategy.download(self.mock_driver, self.reports_dir)
+
+        # Verify
+        self.assertTrue(result)
+        
+        # Verify loop execution (should happen twice)
+        # Select.select_by_value should be called for each year
+        mock_select_instance.select_by_value.assert_has_calls([call("2024"), call("2025")])
+        
+        # Verify file moves
+        mock_wait_and_move.assert_has_calls([
+            call(self.reports_dir, "/tmp/reports/advisorships/2024"),
+            call(self.reports_dir, "/tmp/reports/advisorships/2025")
+        ])
+
+    @patch('agent_sigpesq.strategies.advisorships_strategy.WebDriverWait')
+    @patch('agent_sigpesq.strategies.advisorships_strategy.Select')
+    @patch('agent_sigpesq.strategies.advisorships_strategy.AdvisorshipsDownloadStrategy._wait_and_move_file')
+    def test_partial_download_success(self, mock_wait_and_move, MockSelect, MockWebDriverWait):
+        """Test case where one year fails but overall process returns true if at least one succeeds"""
+        mock_wait_instance = MockWebDriverWait.return_value
+        mock_element = MagicMock()
+        mock_element.tag_name = "select"
+        mock_wait_instance.until.return_value = mock_element
+        
+        mock_select_instance = MockSelect.return_value
+        option1 = MagicMock()
+        option1.get_attribute.return_value = "2024"
+        option2 = MagicMock()
+        option2.get_attribute.return_value = "2025"
+        mock_select_instance.options = [option1, option2]
+        
+        # Fail first download, succeed second
+        mock_wait_and_move.side_effect = [False, True]
+
+        result = self.strategy.download(self.mock_driver, self.reports_dir)
+
+        self.assertTrue(result)
+        
+    @patch('agent_sigpesq.strategies.advisorships_strategy.WebDriverWait')
+    def test_download_critical_failure(self, MockWebDriverWait):
+        # Setup failure
+        mock_wait_instance = MockWebDriverWait.return_value
+        mock_wait_instance.until.side_effect = Exception("Critical Error")
+
+        # Execute
+        result = self.strategy.download(self.mock_driver, self.reports_dir)
+
+        # Verify
+        self.assertFalse(result)

--- a/tests/test_projects_strategy.py
+++ b/tests/test_projects_strategy.py
@@ -1,0 +1,45 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from agent_sigpesq.strategies.projects_strategy import ProjectsDownloadStrategy
+
+class TestProjectsDownloadStrategy(unittest.TestCase):
+    def setUp(self):
+        self.strategy = ProjectsDownloadStrategy()
+        self.mock_driver = MagicMock()
+        self.reports_dir = "/tmp/reports"
+
+    @patch('agent_sigpesq.strategies.projects_strategy.WebDriverWait')
+    @patch('agent_sigpesq.strategies.projects_strategy.ProjectsDownloadStrategy._wait_and_move_file')
+    def test_download_success(self, mock_wait_and_move, MockWebDriverWait):
+        # Setup mocks
+        mock_wait_instance = MockWebDriverWait.return_value
+        mock_element = MagicMock()
+        mock_wait_instance.until.return_value = mock_element
+        mock_wait_and_move.return_value = True
+
+        # Execute
+        result = self.strategy.download(self.mock_driver, self.reports_dir)
+
+        # Verify
+        self.assertTrue(result)
+        
+        # Verify download button interaction
+        self.assertTrue(mock_wait_instance.until.called)
+        mock_element.click.assert_called()
+        
+        # Verify file move
+        mock_wait_and_move.assert_called_with(self.reports_dir, "/tmp/reports/research_projects")
+
+    @patch('agent_sigpesq.strategies.projects_strategy.WebDriverWait')
+    def test_download_failure(self, MockWebDriverWait):
+        # Setup failure
+        mock_wait_instance = MockWebDriverWait.return_value
+        mock_wait_instance.until.side_effect = Exception("Element not found")
+
+        # Execute
+        result = self.strategy.download(self.mock_driver, self.reports_dir)
+
+        # Verify
+        self.assertFalse(result)

--- a/tests/test_research_groups_strategy.py
+++ b/tests/test_research_groups_strategy.py
@@ -1,0 +1,52 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from agent_sigpesq.strategies.research_groups_strategy import ResearchGroupsDownloadStrategy
+
+class TestResearchGroupsDownloadStrategy(unittest.TestCase):
+    def setUp(self):
+        self.strategy = ResearchGroupsDownloadStrategy()
+        self.mock_driver = MagicMock()
+        self.reports_dir = "/tmp/reports"
+
+    @patch('agent_sigpesq.strategies.research_groups_strategy.WebDriverWait')
+    @patch('agent_sigpesq.strategies.research_groups_strategy.ResearchGroupsDownloadStrategy._wait_and_move_file')
+    def test_download_success(self, mock_wait_and_move, MockWebDriverWait):
+        # Setup mocks
+        mock_wait_instance = MockWebDriverWait.return_value
+        mock_element = MagicMock()
+        mock_wait_instance.until.return_value = mock_element
+        mock_wait_and_move.return_value = True
+
+        # Execute
+        result = self.strategy.download(self.mock_driver, self.reports_dir)
+
+        # Verify
+        self.assertTrue(result)
+        
+        # Verify accordion interaction
+        # Note: _ensure_accordion_open is called internally
+        
+        # Verify download button click
+        # The exact call arguments depend on implementation details of _ensure_accordion_open
+        # checking specifically for the download button click
+        button_id = self.strategy.get_button_id()
+        # Ensure we verified expected conditions containing the button ID
+        self.assertTrue(mock_wait_instance.until.called)
+        mock_element.click.assert_called()
+        
+        # Verify file move
+        mock_wait_and_move.assert_called_with(self.reports_dir, "/tmp/reports/research_group")
+
+    @patch('agent_sigpesq.strategies.research_groups_strategy.WebDriverWait')
+    def test_download_failure(self, MockWebDriverWait):
+        # Setup failure
+        mock_wait_instance = MockWebDriverWait.return_value
+        mock_wait_instance.until.side_effect = Exception("Element not found")
+
+        # Execute
+        result = self.strategy.download(self.mock_driver, self.reports_dir)
+
+        # Verify
+        self.assertFalse(result)


### PR DESCRIPTION
I have implemented unit tests for each download strategy.

## Changes
- Created `tests/test_research_groups_strategy.py`
- Created `tests/test_projects_strategy.py`
- Created `tests/test_advisorships_strategy.py`

## Verification
ran `python -m unittest discover tests` and all tests passed.
