### PR TITLE
feat: per-project PDF ETL + Mistral PDF→JSON extraction

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,5 @@
 SIGPESQ_USER=your_username
 SIGPESQ_PASSWORD=your_password
+
+# Only needed for the PDF -> JSON extraction (examples/extract_projects.py):
+MISTRAL_KEY=your_mistral_api_key

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 venv/
+.venv/
+.venv*/
 __pycache__/
 *.pyc
 .env

--- a/README.md
+++ b/README.md
@@ -1,14 +1,43 @@
 # Sigpesq Agent
 
-Automated agent for downloading reports from the Sigpesq portal (IFES) using Playwright and Python.
+Automated agent that logs into the Sigpesq portal (IFES) with **Playwright**, downloads
+research data, and turns project PDFs into structured JSON with the **Mistral API**.
 
 ## 📋 Objective
 
-This agent performs automatic login to the Sigpesq portal and downloads research reports in three categories:
+With a **single login** (the portal rate-limits logins), the agent runs three stages:
 
-- **Research Groups** → `reports/research_groups/`
-- **Research Projects** → `reports/projects/`
-- **Advisorships** → `reports/advisorships/{year}/` (one file per year, from 2016 to 2025)
+1. **Report ETL (Excel)** — downloads the three report categories:
+   - **Research Groups** → `reports/research_group/`
+   - **Research Projects** → `reports/research_projects/`
+   - **Advisorships** → `reports/advisorships/{year}/` (one file per year)
+2. **Per-project PDF ETL** — the **"Projeto"** PDF of every campus project
+   (Diretoria → Projetos → do Campus) → `reports/project_files/<code>.pdf`
+3. **Extraction (Mistral)** — each PDF → structured JSON
+   → `reports/project_files_json/<code>.json` (+ combined `projects.json`)
+
+### Pipeline
+
+```mermaid
+flowchart LR
+    L[Login • single session] --> R[Report ETL<br/>Excel reports]
+    L --> P[Per-project PDF ETL<br/>listaUnidade → Resumo modal → 'Projeto' PDF]
+    P --> X[Mistral extraction<br/>OCR → LLM JSON mode]
+    R --> FS[(reports/)]
+    P --> FS
+    X --> JS[(reports/project_files_json/)]
+```
+
+### Quickstart
+
+```bash
+pip install -e ".[extract]"           # agent + mistralai
+playwright install chromium           # browser
+cp .env.example .env                  # fill SIGPESQ_USER / SIGPESQ_PASSWORD / MISTRAL_KEY
+
+python agent.py download-everything    # stages 1 + 2, one login
+python examples/extract_projects.py    # stage 3 (PDF → JSON)
+```
 
 ## 🛠️ Technologies
 
@@ -23,7 +52,9 @@ This agent performs automatic login to the Sigpesq portal and downloads research
 - **Documentation**: IEEE 1016 SDD (Software Design Description)
 
 > [!NOTE]
-> This library is designed strictly for **downloading files** from the Sigpesq portal. It **does not** interact with or save data to any database. All outputs are saved as files in the local filesystem.
+> This library **downloads files** from the Sigpesq portal and **extracts JSON** from the
+> project PDFs. It **does not** interact with or save data to any database — all outputs
+> (Excel reports, PDFs, JSON) are written to the local filesystem under `reports/`.
 
 ## 🏗️ Architecture
 

--- a/README.md
+++ b/README.md
@@ -264,9 +264,12 @@ Or, programmatically, pass `headless=False` to `SigpesqReportService(...)`.
 ## 🧠 Extracting project data (PDF → JSON via Mistral)
 
 After the PDFs are downloaded, a second step turns each project PDF into structured
-JSON using the **Mistral API**: Mistral OCR (`mistral-ocr-latest`) reads the PDF to
-markdown, then a chat model (`mistral-large-latest`, JSON mode) fills a fixed schema.
-Anything not present in the PDF is left `null` (the model never invents data).
+JSON using the **Mistral API**. To save API calls, digital PDFs are read **locally**
+with `pypdf` (no OCR call); only scanned PDFs (little/no embedded text) fall back to
+**Mistral OCR** (`mistral-ocr-latest`). The extracted text then goes to a chat model
+(`mistral-large-latest`, JSON mode) that fills a fixed schema. Anything not present in
+the PDF is left `null` (the model never invents data). `_meta.fonte_texto` records
+whether each project used `pdf-text` or `ocr`.
 
 ### Setup
 

--- a/README.md
+++ b/README.md
@@ -282,9 +282,22 @@ pip install -e ".[extract]"      # installs mistralai (pinned <2)
 ### Run
 
 ```bash
-python examples/extract_projects.py --limit 5     # test with 5 PDFs
-python examples/extract_projects.py               # all downloaded PDFs
+python examples/extract_projects.py --limit 5     # test with 5 PDFs (synchronous)
+python examples/extract_projects.py               # all downloaded PDFs (synchronous)
 ```
+
+Both examples are **resumable** (skip PDFs whose JSON already exists; `--force` to redo).
+
+**Bulk / cheaper — Mistral Batch API (~50% cost, async):**
+
+```bash
+python examples/extract_projects_batch.py         # batch all not-yet-extracted
+python examples/extract_projects_batch.py --job JOB_ID   # resume: collect a submitted job
+```
+
+The batch path prepares requests from **local pdf text only** (no API calls during
+prep) and runs the chat calls inside a discounted async job. Scanned PDFs (no embedded
+text) are skipped there — run the synchronous `extract_projects.py` for those.
 
 Outputs (filename follows the project code, matching each PDF):
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Sigpesq Agent
 
-Automated agent for downloading reports from the Sigpesq portal (IFES) using Selenium and Python.
+Automated agent for downloading reports from the Sigpesq portal (IFES) using Playwright and Python.
 
 ## 📋 Objective
 
@@ -13,8 +13,9 @@ This agent performs automatic login to the Sigpesq portal and downloads research
 ## 🛠️ Technologies
 
 - **Python 3.8+** - Programming language
-- **Selenium 4.6+** - Browser automation framework
-- **Chrome/Chromium** - Web browser for automation
+- **Playwright** - Browser automation framework (async API)
+- **Chromium** - Web browser for automation (managed by Playwright)
+- **Mistral AI** - OCR + LLM for PDF → structured JSON extraction (optional `[extract]`)
 - **python-dotenv** - Environment variable management
 - **Pydantic** - Data validation and settings management
 - **Design Patterns**: Strategy Pattern, Factory Pattern, Template Method
@@ -29,28 +30,33 @@ This agent performs automatic login to the Sigpesq portal and downloads research
 The project follows **SOLID**, **MVC**, and **Strategy Pattern** principles:
 
 - **Strategy Pattern**: Each report category has its own download strategy
-- **Factory Pattern**: `BrowserFactory` manages Selenium WebDriver instances
-- **Template Method Pattern**: `BaseSeleniumStrategy` defines the skeleton for download operations.
+- **Factory Pattern**: `BrowserFactory` manages Playwright browser contexts
+- **Template Method Pattern**: `BasePlaywrightStrategy` defines the skeleton for download operations.
 - **IEEE SDD Documentation**: Architecture documented in `docs/sdd.md`
 
 ### Folder Structure
 
 ```
 agent_sigpesq/
-├── src/
+├── src/agent_sigpesq/
 │   ├── core/
 │   │   ├── base_agent.py          # Abstract base class for Agent
-│   │   └── browser_factory.py     # WebDriver factory
+│   │   └── browser_factory.py     # Playwright browser-context factory
 │   ├── services/
-│   │   ├── sigpesq_service.py     # Login service
-│   │   └── reports_service.py     # Download orchestrator
-│   └── strategies/
-│       ├── report_download_strategy.py     # BaseSeleniumStrategy & Interface
-│       ├── research_groups_strategy.py     # Research groups strategy
-│       ├── projects_strategy.py            # Projects strategy
-│       └── advisorships_strategy.py        # Advisorships strategy
-├── reports/                       # Output directory for reports
-├── agent.py                       # Main entry point
+│   │   └── reports_service.py     # Login + download orchestrator
+│   ├── strategies/
+│   │   ├── report_download_strategy.py     # BasePlaywrightStrategy & Interface
+│   │   ├── research_groups_strategy.py     # Research groups strategy (Excel)
+│   │   ├── projects_strategy.py            # Projects report strategy (Excel)
+│   │   ├── advisorships_strategy.py        # Advisorships strategy (Excel, per year)
+│   │   └── project_files_strategy.py       # Per-project "Projeto" PDF strategy
+│   └── extraction/
+│       ├── schema.py                       # Pydantic project schema
+│       └── mistral_extractor.py            # PDF -> JSON (Mistral OCR + chat)
+├── examples/                      # Runnable ETL + extraction examples
+├── tests/                         # unittest / pytest suite
+├── reports/                       # Output directory for downloads
+├── agent.py                       # Main CLI entry point
 └── requirements.txt               # Python dependencies
 ```
 
@@ -59,7 +65,7 @@ agent_sigpesq/
 ### Prerequisites
 
 - Python 3.8+
-- Chrome/Chromium installed
+- Playwright Chromium browser (installed via `playwright install chromium`)
 - Sigpesq access credentials
 
 ### Step by Step
@@ -77,7 +83,8 @@ agent_sigpesq/
 
 3. **Install dependencies**:
    ```bash
-   pip install -r requirements.txt
+   pip install -e .                 # installs the agent_sigpesq package + deps
+   playwright install chromium      # download the Chromium browser Playwright drives
    ```
 
 4. **Configure credentials**:
@@ -105,6 +112,91 @@ The agent will:
 3. Download all reports in the three categories
 4. Save files organized by category and year
 
+## 🔄 The two ETLs
+
+The agent ships two independent extract flows:
+
+| ETL | Command | What it downloads | Output |
+|-----|---------|-------------------|--------|
+| **Reports (Excel)** | `download-all` | Research Groups, Research Projects, Advisorships — via the report buttons on `relatorio/lista.aspx` | `reports/research_group/`, `reports/research_projects/`, `reports/advisorships/<year>/` |
+| **Per-project PDFs** | `download-project-files` | The **"Projeto"** PDF of every campus project (Diretoria → Projetos → do Campus) | `reports/project_files/<code>.pdf` |
+
+### Running both ETLs (single login) ⭐
+
+> [!WARNING]
+> The SIGPESQ portal **rate-limits logins** (`"Muitas tentativas. Aguarde alguns segundos."`).
+> Running the two ETLs as **two separate processes logs in twice** and can trip that limit.
+> Run them together in **one login** instead.
+
+```bash
+# one command, one login, both ETLs:
+python agent.py download-everything            # Excel reports + all ~370 project PDFs
+python agent.py download-everything --limit 5  # cap the PDF ETL (quick test)
+```
+
+The equivalent programmatic form — a single `SigpesqReportService` logs in once and
+reuses the same page for every strategy (project-files **last**, because it navigates
+away from the reports page):
+
+```python
+import asyncio
+from agent_sigpesq.services.reports_service import SigpesqReportService
+from agent_sigpesq.strategies import (
+    ResearchGroupsDownloadStrategy,
+    ProjectsDownloadStrategy,
+    AdvisorshipsDownloadStrategy,
+    ProjectFilesDownloadStrategy,
+)
+
+async def main():
+    service = SigpesqReportService(
+        headless=True,
+        download_dir="reports",
+        strategies=[
+            ResearchGroupsDownloadStrategy(),   # ETL 1: Excel reports
+            ProjectsDownloadStrategy(),
+            AdvisorshipsDownloadStrategy(),
+            ProjectFilesDownloadStrategy(limit=None),  # ETL 2: PDFs (keep LAST)
+        ],
+    )
+    await service.run()  # ONE login drives BOTH ETLs
+
+asyncio.run(main())
+```
+
+### Running each ETL on its own
+
+```bash
+python agent.py download-all                    # only the Excel reports
+python agent.py download-project-files          # only the PDFs (all projects)
+python agent.py download-project-files --limit 10   # only the PDFs, first 10
+```
+
+> If you run them as separate commands, **wait a bit between the two** so the second
+> login is not rejected by the rate limit.
+
+### Ready-to-run examples
+
+See [`examples/`](examples/) for runnable scripts:
+
+```bash
+python examples/run_all_etls.py --limit 5   # both ETLs, one login
+python examples/run_reports_etl.py          # Excel only
+python examples/run_pdf_etl.py --limit 5    # PDFs only
+python examples/run_pdf_etl.py --headful    # watch the browser
+```
+
+### CLI reference
+
+```
+python agent.py download-all              # all report files (Excel)
+python agent.py download-groups           # only Research Groups report
+python agent.py download-projects         # only Research Projects report
+python agent.py download-advisorships     # only Advisorships reports
+python agent.py download-project-files    # per-project "Projeto" PDFs   [--limit N]
+python agent.py download-everything       # BOTH ETLs, single login      [--limit N]
+```
+
 ### Output Structure
 
 After execution, reports will be organized in:
@@ -115,57 +207,119 @@ reports/
 │   └── Relatorio_DD_MM_YYYY.xlsx
 ├── research_projects/
 │   └── Relatorio_DD_MM_YYYY.xlsx
-└── advisorships/
-    ├── 2016/
-    │   └── Relatorio_DD_MM_YYYY.xlsx
-    ├── 2017/
-    │   └── Relatorio_DD_MM_YYYY.xlsx
-    ...
-    └── 2026/
-        └── Relatorio_DD_MM_YYYY.xlsx
+├── advisorships/
+│   ├── 2016/
+│   │   └── Relatorio_DD_MM_YYYY.xlsx
+│   ├── 2017/
+│   │   └── Relatorio_DD_MM_YYYY.xlsx
+│   ...
+│   └── 2026/
+│       └── Relatorio_DD_MM_YYYY.xlsx
+└── project_files/               # per-project PDFs (download-project-files)
+    ├── PJ_9760.pdf
+    ├── PJ_9742.pdf
+    └── ...
 ```
 
 ### Headless Mode
 
-By default, the agent runs in headless mode (without graphical interface). To run with visible interface (useful for debugging):
-
-Edit `agent.py` and change:
-```python
-service = SigpesqReportService(headless=False, download_dir="reports")
+By default, the agent runs in headless mode (without graphical interface). To run with a
+visible browser (useful for debugging), use the example scripts' `--headful` flag:
+```bash
+python examples/run_pdf_etl.py --headful --limit 3
 ```
+Or, programmatically, pass `headless=False` to `SigpesqReportService(...)`.
+
+## 🧠 Extracting project data (PDF → JSON via Mistral)
+
+After the PDFs are downloaded, a second step turns each project PDF into structured
+JSON using the **Mistral API**: Mistral OCR (`mistral-ocr-latest`) reads the PDF to
+markdown, then a chat model (`mistral-large-latest`, JSON mode) fills a fixed schema.
+Anything not present in the PDF is left `null` (the model never invents data).
+
+### Setup
+
+```bash
+pip install -e ".[extract]"      # installs mistralai (pinned <2)
+# add your key to .env:
+#   MISTRAL_KEY=your_mistral_api_key
+```
+
+### Run
+
+```bash
+python examples/extract_projects.py --limit 5     # test with 5 PDFs
+python examples/extract_projects.py               # all downloaded PDFs
+```
+
+Outputs (filename follows the project code, matching each PDF):
+
+```
+reports/project_files_json/
+├── PJ_9760.json          # one JSON per project
+├── PJ_9742.json
+├── ...
+└── projects.json         # combined array of all extracted projects
+```
+
+### Extracted fields
+
+`codigo`, `titulo`, `descricao`, `palavras_chave`, `area_conhecimento`,
+`linha_pesquisa`, `objetivos` (geral + especificos), `coordenador`
+(nome/email/campus/titulacao), `equipe` (nome/funcao/instituicao/carga_horaria),
+`datas` (inicio/fim/duracao_meses), `cronograma` (atividade/inicio/fim),
+`financiamento` (valor_total/moeda/fontes), and `_meta`
+(arquivo, paginas, extraido_em, modelo, `campos_ausentes`).
+
+<details>
+<summary>Example output (truncated)</summary>
+
+```json
+{
+  "codigo": "PJ 9760",
+  "titulo": "SIGHUB-IA: Inteligência Adaptativa Multivariável ...",
+  "coordenador": {"nome": "Heitor Caroni Nogueira", "email": "heitor@sigmais.com.br", "campus": "Vitória/ES"},
+  "equipe": [{"nome": "Oscar Machado de Souza", "funcao": "Cientista de Dados", "carga_horaria_semanal": 14.0}],
+  "datas": {"inicio": "2025-01-01", "fim": "2026-12-31", "duracao_meses": 24},
+  "financiamento": {"valor_total": 2016851.68, "moeda": "BRL",
+    "fontes": [{"fonte": "Subvenção Econômica (FAPES)", "valor": 1310953.66, "tipo": "Pública"}]},
+  "_meta": {"arquivo": "PJ_9760.pdf", "paginas": 66, "modelo": "mistral-large-latest", "campos_ausentes": []}
+}
+```
+</details>
+
+> The extraction code lives in [`src/agent_sigpesq/extraction/`](src/agent_sigpesq/extraction/)
+> (`schema.py` = pydantic models, `mistral_extractor.py` = OCR + chat pipeline).
 
 ## 🛠️ Development
 
 ### Adding a New Report Category
 
-1. Create a new strategy in `src/strategies/`:
+1. Create a new strategy in `src/agent_sigpesq/strategies/` (async Playwright):
    ```python
-   from src.strategies.report_download_strategy import BaseSeleniumStrategy
-   from selenium.webdriver.common.by import By
-   
-   class NewCategoryDownloadStrategy(BaseSeleniumStrategy):
+   import os
+   from playwright.async_api import Page
+   from .report_download_strategy import BasePlaywrightStrategy
+
+   class NewCategoryDownloadStrategy(BasePlaywrightStrategy):
        def get_category_name(self) -> str:
            return "Category Name"
-       
+
        def get_button_id(self) -> str:
            return "emit_button_id"
-       
-       def download(self, driver, reports_dir) -> bool:
-           wait = WebDriverWait(driver, 10)
-           
-           # 1. Ensure accordion is open
-           # Pass the button ID to check visibility before trying to open
-           self._ensure_accordion_open(wait, self.get_button_id(), "Accordion Header Text")
-           
-           # 2. Click download
-           driver.find_element(By.ID, self.get_button_id()).click()
-           
-           # 3. Wait for file
+
+       async def download(self, page: Page, reports_dir: str) -> bool:
+           button_id = self.get_button_id()
+
+           # 1. Ensure the accordion holding the button is open
+           await self._ensure_accordion_open(page, button_id, "Accordion Header Text")
+
+           # 2. Click the button and capture the download, saving it to a subfolder
            target_dir = os.path.join(reports_dir, "new_category_folder")
-           return self._wait_and_move_file(reports_dir, target_dir)
+           return await self._handle_download_and_move(page, f"#{button_id}", reports_dir, target_dir)
    ```
 
-2. Register the strategy in `src/services/reports_service.py`:
+2. Register the strategy in `src/agent_sigpesq/services/reports_service.py`:
    ```python
    self.strategies = [
        ResearchGroupsDownloadStrategy(),
@@ -181,16 +335,18 @@ To test only a specific category, create a test script:
 
 ```python
 import asyncio
-from src.services.reports_service import SigpesqReportService
-from src.strategies import ResearchGroupsDownloadStrategy
+from agent_sigpesq.services.reports_service import SigpesqReportService
+from agent_sigpesq.strategies import ResearchGroupsDownloadStrategy
 
 async def test():
-    service = SigpesqReportService(headless=True)
-    service.strategies = [ResearchGroupsDownloadStrategy()]
+    service = SigpesqReportService(headless=True, strategies=[ResearchGroupsDownloadStrategy()])
     await service.run()
 
 asyncio.run(test())
 ```
+
+The `tests/` suite (unittest, run with `pytest`) mocks the Playwright page, so it
+needs no browser or network — that is what CI runs on every push/PR.
 
 ## 📚 Additional Documentation
 
@@ -203,9 +359,11 @@ asyncio.run(test())
 ### Login Error
 
 If login fails intermittently:
-- Verify that credentials in `.env` are correct
-- Try running in non-headless mode to visualize the problem
-- Check if Chrome/Chromium is up to date
+- Verify that credentials in `.env` are correct (`SIGPESQ_USER` = CPF, `SIGPESQ_PASSWORD`)
+- **Rate limit:** the portal rejects rapid re-logins with *"Muitas tentativas. Aguarde alguns segundos."*
+  Use a **single login** per run (e.g. `download-everything`) and wait a few minutes
+  before retrying — every new attempt resets the cooldown.
+- Try running with `--headful` (examples) to visualize the problem
 
 ### Downloads not appearing
 
@@ -213,11 +371,11 @@ If login fails intermittently:
 - Ensure there is sufficient disk space
 - Check execution logs to identify specific errors
 
-### Incompatible ChromeDriver
+### Browser not installed
 
-Selenium 4.6+ automatically manages ChromeDriver. If there are issues:
+Playwright manages its own Chromium. If the browser is missing:
 ```bash
-pip install --upgrade selenium
+playwright install chromium
 ```
 
 ## 📄 License

--- a/agent.py
+++ b/agent.py
@@ -5,7 +5,8 @@ from agent_sigpesq.services.reports_service import SigpesqReportService
 from agent_sigpesq.strategies import (
     ResearchGroupsDownloadStrategy,
     ProjectsDownloadStrategy,
-    AdvisorshipsDownloadStrategy
+    AdvisorshipsDownloadStrategy,
+    ProjectFilesDownloadStrategy
 )
 
 async def main():
@@ -17,6 +18,18 @@ async def main():
     subparsers.add_parser("download-groups", help="Download only Research Groups reports")
     subparsers.add_parser("download-projects", help="Download only Research Projects reports")
     subparsers.add_parser("download-advisorships", help="Download only Advisorships reports")
+    pf = subparsers.add_parser(
+        "download-project-files",
+        help="Download the 'Projeto' PDF of each campus project (Diretoria -> Projetos -> do Campus)"
+    )
+    pf.add_argument("--limit", type=int, default=None,
+                    help="Max number of projects to process (default: all)")
+    ev = subparsers.add_parser(
+        "download-everything",
+        help="Run BOTH ETLs in a SINGLE login: report files (Excel) + per-project PDFs"
+    )
+    ev.add_argument("--limit", type=int, default=None,
+                    help="Max number of projects for the PDF ETL (default: all)")
 
     args = parser.parse_args()
 
@@ -30,6 +43,18 @@ async def main():
     elif args.command == "download-advisorships":
         strategies = [AdvisorshipsDownloadStrategy()]
         print("Configuration: Downloading Advisorships only.")
+    elif args.command == "download-project-files":
+        strategies = [ProjectFilesDownloadStrategy(limit=args.limit)]
+        print(f"Configuration: Downloading per-project PDF files (limit={args.limit}).")
+    elif args.command == "download-everything":
+        # Both ETLs, one login. project-files LAST: it navigates away from the reports page.
+        strategies = [
+            ResearchGroupsDownloadStrategy(),
+            ProjectsDownloadStrategy(),
+            AdvisorshipsDownloadStrategy(),
+            ProjectFilesDownloadStrategy(limit=args.limit),
+        ]
+        print(f"Configuration: Running BOTH ETLs (reports + PDFs) in one login (limit={args.limit}).")
     else:
         print("Configuration: Downloading ALL reports.")
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,8 @@ the same authenticated session (the portal rate-limits logins).
 | [`run_reports_etl.py`](run_reports_etl.py) | ETL 1 — report files (Excel): groups, projects, advisorships | `reports/research_group/`, `reports/research_projects/`, `reports/advisorships/<year>/` |
 | [`run_pdf_etl.py`](run_pdf_etl.py) | ETL 2 — the "Projeto" PDF of every campus project | `reports/project_files/<code>.pdf` |
 | [`run_all_etls.py`](run_all_etls.py) | **Both** ETLs in a single login | all of the above |
-| [`extract_projects.py`](extract_projects.py) | PDF → JSON via Mistral (OCR + LLM) | `reports/project_files_json/<code>.json` + `projects.json` |
+| [`extract_projects.py`](extract_projects.py) | PDF → JSON via Mistral (text-first, OCR fallback) | `reports/project_files_json/<code>.json` + `projects.json` |
+| [`extract_projects_batch.py`](extract_projects_batch.py) | Bulk PDF → JSON via Mistral **Batch API** (~50% cost, async) | same as above |
 
 ## Setup
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,36 @@
+# Examples
+
+Runnable examples for the two SIGPESQ ETLs. All of them log in **once** and reuse
+the same authenticated session (the portal rate-limits logins).
+
+| Script | What it does | Output |
+|---|---|---|
+| [`run_reports_etl.py`](run_reports_etl.py) | ETL 1 — report files (Excel): groups, projects, advisorships | `reports/research_group/`, `reports/research_projects/`, `reports/advisorships/<year>/` |
+| [`run_pdf_etl.py`](run_pdf_etl.py) | ETL 2 — the "Projeto" PDF of every campus project | `reports/project_files/<code>.pdf` |
+| [`run_all_etls.py`](run_all_etls.py) | **Both** ETLs in a single login | all of the above |
+| [`extract_projects.py`](extract_projects.py) | PDF → JSON via Mistral (OCR + LLM) | `reports/project_files_json/<code>.json` + `projects.json` |
+
+## Setup
+
+```bash
+pip install -e .            # or: export PYTHONPATH=src
+cp .env.example .env        # then fill SIGPESQ_USER / SIGPESQ_PASSWORD
+```
+
+## Run
+
+```bash
+python examples/run_all_etls.py              # both ETLs, one login
+python examples/run_all_etls.py --limit 5    # cap the PDF ETL for a quick test
+python examples/run_reports_etl.py           # only the Excel reports
+python examples/run_pdf_etl.py --limit 5     # only PDFs, first 5 projects
+python examples/run_pdf_etl.py --headful     # watch the browser
+
+# PDF -> JSON extraction (needs MISTRAL_KEY in .env, and: pip install -e ".[extract]")
+python examples/extract_projects.py --limit 5
+```
+
+> ⚠️ **One login only.** Do **not** launch two ETL processes back-to-back — that
+> logs in twice and trips the portal's rate limit
+> ("Muitas tentativas. Aguarde alguns segundos."). Use `run_all_etls.py`
+> (or `python agent.py download-everything`) to run both in a single login.

--- a/examples/extract_projects.py
+++ b/examples/extract_projects.py
@@ -1,0 +1,77 @@
+"""
+Example: extract structured JSON from downloaded project PDFs using the Mistral API.
+
+For each PDF in reports/project_files/*.pdf it runs Mistral OCR + a JSON-mode chat
+extraction (see agent_sigpesq.extraction) and writes:
+  reports/project_files_json/<code>.json   (one per project, e.g. PJ_9760.json)
+  reports/project_files_json/projects.json (combined array)
+
+Setup:
+  pip install -e ".[extract]"      # or: pip install "mistralai>=1.9,<2" pydantic python-dotenv
+  # .env must contain MISTRAL_KEY=...
+
+Run:
+  python examples/extract_projects.py --limit 5      # test with 5 PDFs
+  python examples/extract_projects.py                # all downloaded PDFs
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import sys
+
+from dotenv import load_dotenv
+
+from agent_sigpesq.extraction import ProjectExtractor
+
+load_dotenv()
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Extract project JSON from PDFs via Mistral.")
+    p.add_argument("--pdf-dir", default="reports/project_files", help="Folder with project PDFs.")
+    p.add_argument("--out-dir", default="reports/project_files_json", help="Output folder for JSON.")
+    p.add_argument("--limit", type=int, default=None, help="Max PDFs to process (default: all).")
+    args = p.parse_args()
+
+    pdfs = sorted(glob.glob(os.path.join(args.pdf_dir, "*.pdf")))
+    if args.limit is not None:
+        pdfs = pdfs[: args.limit]
+    if not pdfs:
+        print(f"No PDFs found in {args.pdf_dir}. Run the PDF ETL first.")
+        return 1
+
+    os.makedirs(args.out_dir, exist_ok=True)
+    extractor = ProjectExtractor()
+
+    combined = []
+    ok = 0
+    for i, pdf in enumerate(pdfs, 1):
+        name = os.path.basename(pdf)
+        print(f"[{i}/{len(pdfs)}] {name} ...", flush=True)
+        try:
+            projeto = extractor.extract_project(pdf)
+        except Exception as e:
+            print(f"    FAILED: {e}")
+            continue
+        data = projeto.model_dump(by_alias=True)
+        stem = os.path.splitext(name)[0]
+        with open(os.path.join(args.out_dir, f"{stem}.json"), "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+        combined.append(data)
+        ok += 1
+        missing = data["_meta"]["campos_ausentes"]
+        print(f"    OK -> {stem}.json"
+              + (f"  (campos ausentes: {', '.join(missing)})" if missing else ""))
+
+    with open(os.path.join(args.out_dir, "projects.json"), "w", encoding="utf-8") as f:
+        json.dump(combined, f, ensure_ascii=False, indent=2)
+
+    print(f"\nDone: {ok}/{len(pdfs)} extracted -> {args.out_dir}/ (+ projects.json)")
+    return 0 if ok > 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/extract_projects.py
+++ b/examples/extract_projects.py
@@ -73,7 +73,9 @@ def main() -> int:
 
     # rebuild the combined array from ALL per-project JSON files on disk
     combined = []
-    for jf in sorted(glob.glob(os.path.join(args.out_dir, "PJ_*.json"))):
+    for jf in sorted(glob.glob(os.path.join(args.out_dir, "*.json"))):
+        if os.path.basename(jf) == "projects.json":
+            continue
         with open(jf, encoding="utf-8") as f:
             combined.append(json.load(f))
     with open(os.path.join(args.out_dir, "projects.json"), "w", encoding="utf-8") as f:

--- a/examples/extract_projects.py
+++ b/examples/extract_projects.py
@@ -34,6 +34,8 @@ def main() -> int:
     p.add_argument("--pdf-dir", default="reports/project_files", help="Folder with project PDFs.")
     p.add_argument("--out-dir", default="reports/project_files_json", help="Output folder for JSON.")
     p.add_argument("--limit", type=int, default=None, help="Max PDFs to process (default: all).")
+    p.add_argument("--force", action="store_true",
+                   help="Re-extract even if the JSON already exists (default: skip existing).")
     args = p.parse_args()
 
     pdfs = sorted(glob.glob(os.path.join(args.pdf_dir, "*.pdf")))
@@ -46,10 +48,15 @@ def main() -> int:
     os.makedirs(args.out_dir, exist_ok=True)
     extractor = ProjectExtractor()
 
-    combined = []
-    ok = 0
+    ok = skipped = 0
     for i, pdf in enumerate(pdfs, 1):
         name = os.path.basename(pdf)
+        stem = os.path.splitext(name)[0]
+        out_path = os.path.join(args.out_dir, f"{stem}.json")
+        # resumable: skip PDFs already extracted unless --force
+        if not args.force and os.path.exists(out_path):
+            skipped += 1
+            continue
         print(f"[{i}/{len(pdfs)}] {name} ...", flush=True)
         try:
             projeto = extractor.extract_project(pdf)
@@ -57,20 +64,24 @@ def main() -> int:
             print(f"    FAILED: {e}")
             continue
         data = projeto.model_dump(by_alias=True)
-        stem = os.path.splitext(name)[0]
-        with open(os.path.join(args.out_dir, f"{stem}.json"), "w", encoding="utf-8") as f:
+        with open(out_path, "w", encoding="utf-8") as f:
             json.dump(data, f, ensure_ascii=False, indent=2)
-        combined.append(data)
         ok += 1
         missing = data["_meta"]["campos_ausentes"]
         print(f"    OK -> {stem}.json"
               + (f"  (campos ausentes: {', '.join(missing)})" if missing else ""))
 
+    # rebuild the combined array from ALL per-project JSON files on disk
+    combined = []
+    for jf in sorted(glob.glob(os.path.join(args.out_dir, "PJ_*.json"))):
+        with open(jf, encoding="utf-8") as f:
+            combined.append(json.load(f))
     with open(os.path.join(args.out_dir, "projects.json"), "w", encoding="utf-8") as f:
         json.dump(combined, f, ensure_ascii=False, indent=2)
 
-    print(f"\nDone: {ok}/{len(pdfs)} extracted -> {args.out_dir}/ (+ projects.json)")
-    return 0 if ok > 0 else 1
+    print(f"\nDone: {ok} extracted, {skipped} skipped (already done), "
+          f"{len(combined)} in projects.json -> {args.out_dir}/")
+    return 0 if (ok > 0 or skipped > 0) else 1
 
 
 if __name__ == "__main__":

--- a/examples/extract_projects_batch.py
+++ b/examples/extract_projects_batch.py
@@ -90,7 +90,9 @@ def main() -> int:
 
 def _rebuild_combined(out_dir: str) -> int:
     combined = []
-    for jf in sorted(glob.glob(os.path.join(out_dir, "PJ_*.json"))):
+    for jf in sorted(glob.glob(os.path.join(out_dir, "*.json"))):
+        if os.path.basename(jf) == "projects.json":
+            continue
         with open(jf, encoding="utf-8") as f:
             combined.append(json.load(f))
     if combined:

--- a/examples/extract_projects_batch.py
+++ b/examples/extract_projects_batch.py
@@ -1,0 +1,104 @@
+"""
+Bulk PDF -> JSON extraction via the Mistral Batch API (~50% cheaper, async).
+
+Prepares chat requests from LOCAL pdf text (no API calls during prep), submits
+one batch job, polls until it finishes, and writes one JSON per project. Scanned
+PDFs (no embedded text) are skipped here -- run extract_projects.py for those.
+
+Setup:
+  pip install -e ".[extract]"      # mistralai + pypdf
+  # .env must contain MISTRAL_KEY=...
+
+Run:
+  python examples/extract_projects_batch.py                 # all not-yet-extracted
+  python examples/extract_projects_batch.py --limit 50      # cap request count
+  python examples/extract_projects_batch.py --job JOB_ID    # resume: just collect a job
+  python examples/extract_projects_batch.py --poll 60       # poll interval (s)
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import sys
+import time
+
+from dotenv import load_dotenv
+
+from agent_sigpesq.extraction.batch_extractor import BatchProjectExtractor, TERMINAL_STATES
+
+load_dotenv()
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Bulk project extraction via Mistral Batch API.")
+    p.add_argument("--pdf-dir", default="reports/project_files")
+    p.add_argument("--out-dir", default="reports/project_files_json")
+    p.add_argument("--limit", type=int, default=None, help="Max requests to batch.")
+    p.add_argument("--force", action="store_true", help="Include PDFs already extracted.")
+    p.add_argument("--poll", type=int, default=30, help="Poll interval in seconds.")
+    p.add_argument("--job", default=None, help="Existing batch job id to just collect.")
+    args = p.parse_args()
+
+    extractor = BatchProjectExtractor()
+
+    # collect-only mode for an already-submitted job
+    if args.job:
+        pdfs = sorted(glob.glob(os.path.join(args.pdf_dir, "*.pdf")))
+        _, meta, _ = extractor.build_requests(pdfs)  # rebuild custom_id -> meta map
+        job = extractor.get_job(args.job)
+        written, errors = extractor.collect_results(job, meta, args.out_dir)
+        print(f"Collected job {args.job}: {written} written, {errors} errors.")
+        return _rebuild_combined(args.out_dir)
+
+    pdfs = sorted(glob.glob(os.path.join(args.pdf_dir, "*.pdf")))
+    if not args.force:
+        pdfs = [f for f in pdfs
+                if not os.path.exists(os.path.join(
+                    args.out_dir, os.path.splitext(os.path.basename(f))[0] + ".json"))]
+    if args.limit is not None:
+        pdfs = pdfs[: args.limit]
+    if not pdfs:
+        print("Nothing to extract (all done?). Use --force to re-extract.")
+        return _rebuild_combined(args.out_dir)
+
+    jsonl, meta, skipped = extractor.build_requests(pdfs)
+    print(f"Prepared {len(meta)} batch requests; {len(skipped)} scanned PDF(s) skipped "
+          f"(use extract_projects.py for those).")
+    if not meta:
+        print("No digital PDFs to batch.")
+        return 1
+
+    job_id = extractor.submit(jsonl)
+    print(f"Submitted batch job: {job_id}", flush=True)
+
+    while True:
+        job = extractor.get_job(job_id)
+        status = getattr(job, "status", "?")
+        done = getattr(job, "completed_requests", None)
+        total = getattr(job, "total_requests", None)
+        print(f"  status={status} completed={done}/{total}", flush=True)
+        if status in TERMINAL_STATES:
+            break
+        time.sleep(args.poll)
+
+    written, errors = extractor.collect_results(job, meta, args.out_dir)
+    print(f"Job {job_id} {getattr(job, 'status', '?')}: {written} written, {errors} errors.")
+    return _rebuild_combined(args.out_dir)
+
+
+def _rebuild_combined(out_dir: str) -> int:
+    combined = []
+    for jf in sorted(glob.glob(os.path.join(out_dir, "PJ_*.json"))):
+        with open(jf, encoding="utf-8") as f:
+            combined.append(json.load(f))
+    if combined:
+        with open(os.path.join(out_dir, "projects.json"), "w", encoding="utf-8") as f:
+            json.dump(combined, f, ensure_ascii=False, indent=2)
+    print(f"projects.json now has {len(combined)} projects.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/run_all_etls.py
+++ b/examples/run_all_etls.py
@@ -1,0 +1,67 @@
+"""
+Example: run BOTH SIGPESQ ETLs with a SINGLE login.
+
+  ETL 1 (report files / Excel): Research Groups, Research Projects, Advisorships
+                                -> downloaded via the report buttons on relatorio/lista.aspx
+  ETL 2 (per-project PDFs):     the "Projeto" PDF of every campus project
+                                -> Diretoria > Projetos > do Campus
+
+WHY one login: the SIGPESQ portal rate-limits logins ("Muitas tentativas.
+Aguarde alguns segundos."). Running the two ETLs as two separate processes logs
+in twice and can trip that limit. `SigpesqReportService.run()` logs in ONCE and
+then reuses the same authenticated page for every strategy, so we pass all the
+strategies to a single service instance.
+
+Order matters: ProjectFilesDownloadStrategy must come LAST because it navigates
+away from the reports page to projeto/listaUnidade.aspx.
+
+Run it:
+    pip install -e .          # or: export PYTHONPATH=src
+    # put SIGPESQ_USER / SIGPESQ_PASSWORD in .env
+    python examples/run_all_etls.py
+    python examples/run_all_etls.py --limit 5      # cap the PDF ETL for a quick test
+    python examples/run_all_etls.py --headful      # watch the browser
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+
+from agent_sigpesq.services.reports_service import SigpesqReportService
+from agent_sigpesq.strategies import (
+    ResearchGroupsDownloadStrategy,
+    ProjectsDownloadStrategy,
+    AdvisorshipsDownloadStrategy,
+    ProjectFilesDownloadStrategy,
+)
+
+
+async def main(limit: int | None, headless: bool, out_dir: str) -> bool:
+    service = SigpesqReportService(
+        headless=headless,
+        download_dir=out_dir,
+        strategies=[
+            # --- ETL 1: report files (Excel) ---
+            ResearchGroupsDownloadStrategy(),
+            ProjectsDownloadStrategy(),
+            AdvisorshipsDownloadStrategy(),
+            # --- ETL 2: per-project PDFs (keep LAST: it navigates away) ---
+            ProjectFilesDownloadStrategy(limit=limit),
+        ],
+    )
+    # ONE login here drives BOTH ETLs.
+    return await service.run()
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser(description="Run both SIGPESQ ETLs with a single login.")
+    p.add_argument("--limit", type=int, default=None,
+                   help="Max projects for the PDF ETL (default: all 370).")
+    p.add_argument("--out", default="reports", help="Output directory (default: reports).")
+    p.add_argument("--headful", action="store_true", help="Show the browser window.")
+    args = p.parse_args()
+
+    ok = asyncio.run(main(limit=args.limit, headless=not args.headful, out_dir=args.out))
+    print("All ETLs finished." if ok else "One or more ETLs failed.")
+    sys.exit(0 if ok else 1)

--- a/examples/run_pdf_etl.py
+++ b/examples/run_pdf_etl.py
@@ -1,0 +1,44 @@
+"""
+Example: ETL 2 only -- per-project PDFs.
+
+Downloads the "Projeto" PDF of every campus research project
+(Diretoria > Projetos > do Campus) in a single login:
+  reports/project_files/<project-code>.pdf   e.g. PJ_9760.pdf
+
+Draft projects ("Salvo") have no uploaded file and are skipped.
+
+Run it:
+    pip install -e .          # or: export PYTHONPATH=src
+    python examples/run_pdf_etl.py               # all ~370 projects
+    python examples/run_pdf_etl.py --limit 5     # quick test
+    python examples/run_pdf_etl.py --headful     # watch the browser
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+
+from agent_sigpesq.services.reports_service import SigpesqReportService
+from agent_sigpesq.strategies import ProjectFilesDownloadStrategy
+
+
+async def main(limit: int | None, headless: bool, out_dir: str) -> bool:
+    service = SigpesqReportService(
+        headless=headless,
+        download_dir=out_dir,
+        strategies=[ProjectFilesDownloadStrategy(limit=limit)],
+    )
+    return await service.run()  # single login
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser(description="Run the per-project PDF ETL with a single login.")
+    p.add_argument("--limit", type=int, default=None, help="Max projects (default: all).")
+    p.add_argument("--out", default="reports", help="Output directory (default: reports).")
+    p.add_argument("--headful", action="store_true", help="Show the browser window.")
+    args = p.parse_args()
+
+    ok = asyncio.run(main(limit=args.limit, headless=not args.headful, out_dir=args.out))
+    print("PDF ETL finished." if ok else "PDF ETL failed.")
+    sys.exit(0 if ok else 1)

--- a/examples/run_reports_etl.py
+++ b/examples/run_reports_etl.py
@@ -1,0 +1,50 @@
+"""
+Example: ETL 1 only -- report files (Excel).
+
+Downloads the three report categories via the report buttons on
+relatorio/lista.aspx, in a single login:
+  - Research Groups   -> reports/research_group/
+  - Research Projects -> reports/research_projects/
+  - Advisorships      -> reports/advisorships/<year>/
+
+Run it:
+    pip install -e .          # or: export PYTHONPATH=src
+    python examples/run_reports_etl.py
+    python examples/run_reports_etl.py --headful   # watch the browser
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+
+from agent_sigpesq.services.reports_service import SigpesqReportService
+from agent_sigpesq.strategies import (
+    ResearchGroupsDownloadStrategy,
+    ProjectsDownloadStrategy,
+    AdvisorshipsDownloadStrategy,
+)
+
+
+async def main(headless: bool, out_dir: str) -> bool:
+    service = SigpesqReportService(
+        headless=headless,
+        download_dir=out_dir,
+        strategies=[
+            ResearchGroupsDownloadStrategy(),
+            ProjectsDownloadStrategy(),
+            AdvisorshipsDownloadStrategy(),
+        ],
+    )
+    return await service.run()  # single login
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser(description="Run the report (Excel) ETL with a single login.")
+    p.add_argument("--out", default="reports", help="Output directory (default: reports).")
+    p.add_argument("--headful", action="store_true", help="Show the browser window.")
+    args = p.parse_args()
+
+    ok = asyncio.run(main(headless=not args.headful, out_dir=args.out))
+    print("Reports ETL finished." if ok else "Reports ETL failed.")
+    sys.exit(0 if ok else 1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,11 +18,13 @@ Homepage = "https://github.com/ifesserra-lab/sigpesq_agent"
 [project.optional-dependencies]
 extract = [
     "mistralai>=1.9,<2",
+    "pypdf>=4",
 ]
 dev = [
     "pytest",
     "pytest-cov",
     "mistralai>=1.9,<2",
+    "pypdf>=4",
     "black",
     "flake8",
     "isort",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,13 @@ dependencies = ["playwright", "python-dotenv", "pydantic"]
 Homepage = "https://github.com/ifesserra-lab/sigpesq_agent"
 
 [project.optional-dependencies]
+extract = [
+    "mistralai>=1.9,<2",
+]
 dev = [
     "pytest",
     "pytest-cov",
+    "mistralai>=1.9,<2",
     "black",
     "flake8",
     "isort",

--- a/src/agent_sigpesq/extraction/__init__.py
+++ b/src/agent_sigpesq/extraction/__init__.py
@@ -1,0 +1,19 @@
+"""
+PDF -> structured JSON extraction for SIGPESQ project files, using the Mistral API.
+
+Pipeline: Mistral OCR (mistral-ocr-latest) turns each project PDF into markdown,
+then a chat model (mistral-large-latest, JSON mode) fills the project schema.
+
+`ProjectExtractor` is imported lazily so that `schema` (pure pydantic) can be used
+without pulling in the optional `mistralai` dependency.
+"""
+from .schema import Projeto
+
+__all__ = ["Projeto", "ProjectExtractor"]
+
+
+def __getattr__(name):
+    if name == "ProjectExtractor":
+        from .mistral_extractor import ProjectExtractor
+        return ProjectExtractor
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/agent_sigpesq/extraction/__init__.py
+++ b/src/agent_sigpesq/extraction/__init__.py
@@ -9,11 +9,14 @@ without pulling in the optional `mistralai` dependency.
 """
 from .schema import Projeto
 
-__all__ = ["Projeto", "ProjectExtractor"]
+__all__ = ["Projeto", "ProjectExtractor", "BatchProjectExtractor"]
 
 
 def __getattr__(name):
     if name == "ProjectExtractor":
         from .mistral_extractor import ProjectExtractor
         return ProjectExtractor
+    if name == "BatchProjectExtractor":
+        from .batch_extractor import BatchProjectExtractor
+        return BatchProjectExtractor
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/agent_sigpesq/extraction/batch_extractor.py
+++ b/src/agent_sigpesq/extraction/batch_extractor.py
@@ -1,0 +1,110 @@
+"""
+Bulk PDF -> JSON extraction via the Mistral Batch API (~50% cheaper than
+synchronous calls; asynchronous).
+
+Flow:
+  1. build a JSONL of chat requests (one line per project), using text read
+     locally with pypdf -- no API calls during preparation. Scanned PDFs (no
+     embedded text) are skipped here and left to the synchronous extractor.
+  2. upload the JSONL (purpose="batch") and create a batch job on
+     /v1/chat/completions.
+  3. poll the job until it reaches a terminal state.
+  4. download the results, validate each into a Projeto, and write the JSON.
+
+The heavy chat calls run inside the batch (discounted). Preparation is offline.
+"""
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from typing import Dict, List, Optional, Tuple
+
+from .mistral_extractor import ProjectExtractor, MIN_PDF_TEXT_CHARS, _codigo_from_filename
+
+TERMINAL_STATES = {"SUCCESS", "FAILED", "CANCELLED", "CANCELLATION_REQUESTED",
+                   "TIMEOUT_EXCEEDED"}
+
+
+class BatchProjectExtractor(ProjectExtractor):
+    """Prepare, submit, and collect a Mistral batch job for project extraction."""
+
+    def build_requests(self, pdf_paths: List[str]) -> Tuple[str, Dict[str, dict], List[str]]:
+        """Return (jsonl_text, meta_by_custom_id, skipped_scanned).
+
+        Only digital PDFs (embedded text) are batched; scanned PDFs are returned
+        in `skipped_scanned` so the caller can handle them with the sync path.
+        """
+        lines: List[str] = []
+        meta: Dict[str, dict] = {}
+        skipped: List[str] = []
+        for pdf in pdf_paths:
+            stem = os.path.splitext(os.path.basename(pdf))[0]
+            codigo = _codigo_from_filename(pdf)
+            text, num_pages = self.pdf_text(pdf)
+            if len(text.strip()) < MIN_PDF_TEXT_CHARS:
+                skipped.append(pdf)  # scanned -> needs OCR, not batched here
+                continue
+            body = {
+                "messages": self.build_messages(codigo, text),
+                "response_format": {"type": "json_object"},
+                "temperature": 0,
+            }
+            lines.append(json.dumps({"custom_id": stem, "body": body}, ensure_ascii=False))
+            meta[stem] = {"codigo": codigo, "arquivo": os.path.basename(pdf),
+                          "paginas": num_pages, "fonte_texto": "pdf-text"}
+        return "\n".join(lines) + ("\n" if lines else ""), meta, skipped
+
+    def submit(self, jsonl_text: str) -> str:
+        """Upload the JSONL and create a chat-completions batch job. Returns job id."""
+        uploaded = self.client.files.upload(
+            file={"file_name": "batch_input.jsonl", "content": jsonl_text.encode("utf-8")},
+            purpose="batch",
+        )
+        job = self.client.batch.jobs.create(
+            input_files=[uploaded.id],
+            endpoint="/v1/chat/completions",
+            model=self.chat_model,
+            metadata={"job": "sigpesq-project-extraction"},
+        )
+        return job.id
+
+    def get_job(self, job_id: str):
+        return self.client.batch.jobs.get(job_id=job_id)
+
+    def collect_results(self, job, meta: Dict[str, dict], out_dir: str) -> Tuple[int, int]:
+        """Download the job's output file, write one JSON per project.
+
+        Returns (written, errors).
+        """
+        output_file_id = getattr(job, "output_file", None)
+        if not output_file_id:
+            return 0, 0
+        resp = self.client.files.download(file_id=output_file_id)
+        written = errors = 0
+        os.makedirs(out_dir, exist_ok=True)
+        for raw_line in resp.text.splitlines():
+            raw_line = raw_line.strip()
+            if not raw_line:
+                continue
+            try:
+                rec = json.loads(raw_line)
+                custom_id = rec.get("custom_id")
+                info = meta.get(custom_id)
+                if not info:
+                    continue
+                content = rec["response"]["body"]["choices"][0]["message"]["content"]
+                data = json.loads(content)
+                projeto = self.finalize(
+                    info["codigo"], data, info["arquivo"], info["paginas"], info["fonte_texto"]
+                )
+                with open(os.path.join(out_dir, f"{custom_id}.json"), "w", encoding="utf-8") as f:
+                    json.dump(projeto.model_dump(by_alias=True), f, ensure_ascii=False, indent=2)
+                written += 1
+            except Exception:
+                errors += 1
+        return written, errors
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()

--- a/src/agent_sigpesq/extraction/mistral_extractor.py
+++ b/src/agent_sigpesq/extraction/mistral_extractor.py
@@ -16,6 +16,7 @@ from .schema import Projeto, JSON_TEMPLATE
 OCR_MODEL = "mistral-ocr-latest"
 CHAT_MODEL = "mistral-large-latest"
 MAX_MARKDOWN_CHARS = 180_000  # keep the prompt within the model context window
+MIN_PDF_TEXT_CHARS = 400      # below this, treat the PDF as scanned and fall back to OCR
 
 SYSTEM_PROMPT = (
     "Você extrai dados estruturados de projetos de pesquisa a partir do texto "
@@ -82,7 +83,22 @@ class ProjectExtractor:
         self.ocr_model = ocr_model
         self.chat_model = chat_model
 
-    # --- step 1: OCR the PDF to markdown ---
+    # --- step 1a: cheap path -- read embedded text locally (no API call) ---
+    def pdf_text(self, pdf_path: str) -> Tuple[str, int]:
+        """Extract embedded text with pypdf. Returns ("", 0) for scanned PDFs or
+        if pypdf is unavailable, so the caller can fall back to OCR."""
+        try:
+            from pypdf import PdfReader
+        except Exception:
+            return "", 0
+        try:
+            reader = PdfReader(pdf_path)
+            text = "\n".join((pg.extract_text() or "") for pg in reader.pages)
+            return text, len(reader.pages)
+        except Exception:
+            return "", 0
+
+    # --- step 1b: OCR the PDF to markdown (for scanned PDFs) ---
     def ocr_pdf(self, pdf_path: str) -> Tuple[str, int]:
         """Upload the PDF, OCR it, and return (markdown_text, num_pages)."""
         with open(pdf_path, "rb") as f:
@@ -123,8 +139,15 @@ class ProjectExtractor:
     # --- full pipeline for one PDF ---
     def extract_project(self, pdf_path: str) -> Projeto:
         codigo = _codigo_from_filename(pdf_path)
-        markdown, num_pages = self.ocr_pdf(pdf_path)
-        raw = self.extract_fields(codigo, markdown)
+        # cheap path first: use embedded text (no OCR call) when the PDF is digital;
+        # fall back to OCR only for scanned PDFs with little/no extractable text.
+        text, num_pages = self.pdf_text(pdf_path)
+        if len(text.strip()) >= MIN_PDF_TEXT_CHARS:
+            source = "pdf-text"
+        else:
+            text, num_pages = self.ocr_pdf(pdf_path)
+            source = "ocr"
+        raw = self.extract_fields(codigo, text)
 
         raw["codigo"] = codigo  # filename is authoritative
         # Defensive: 'equipe' must be real people. Drop entries without a name
@@ -140,6 +163,7 @@ class ProjectExtractor:
             "paginas": num_pages,
             "extraido_em": datetime.now(timezone.utc).isoformat(),
             "modelo": self.chat_model,
+            "fonte_texto": source,
             "campos_ausentes": [],
         }
         projeto = Projeto.model_validate(raw)

--- a/src/agent_sigpesq/extraction/mistral_extractor.py
+++ b/src/agent_sigpesq/extraction/mistral_extractor.py
@@ -116,39 +116,42 @@ class ProjectExtractor:
         markdown = "\n\n".join((pg.markdown or "") for pg in pages)
         return markdown, len(pages)
 
-    # --- step 2: structured extraction via chat (JSON mode) ---
-    def extract_fields(self, codigo: str, markdown: str) -> dict:
-        text = markdown[:MAX_MARKDOWN_CHARS]
+    # --- prompt shared by the sync and batch paths ---
+    def build_messages(self, codigo: str, text: str) -> list:
+        """Build the chat messages for one project's structured extraction."""
         user_prompt = (
             f"Código do projeto (use exatamente este valor em 'codigo'): {codigo}\n\n"
             f"Formato JSON esperado (modelo das chaves):\n"
             f"{json.dumps(JSON_TEMPLATE, ensure_ascii=False, indent=2)}\n\n"
-            f"Texto do PDF do projeto (markdown do OCR):\n\"\"\"\n{text}\n\"\"\""
+            f"Texto do PDF do projeto:\n\"\"\"\n{text[:MAX_MARKDOWN_CHARS]}\n\"\"\""
         )
+        return [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": user_prompt},
+        ]
+
+    # --- text source: local first, OCR fallback ---
+    def text_for(self, pdf_path: str) -> Tuple[str, int, str]:
+        """Return (text, num_pages, source) using embedded text when possible."""
+        text, num_pages = self.pdf_text(pdf_path)
+        if len(text.strip()) >= MIN_PDF_TEXT_CHARS:
+            return text, num_pages, "pdf-text"
+        text, num_pages = self.ocr_pdf(pdf_path)
+        return text, num_pages, "ocr"
+
+    # --- step 2: structured extraction via chat (JSON mode) ---
+    def extract_fields(self, codigo: str, text: str) -> dict:
         resp = self.client.chat.complete(
             model=self.chat_model,
-            messages=[
-                {"role": "system", "content": SYSTEM_PROMPT},
-                {"role": "user", "content": user_prompt},
-            ],
+            messages=self.build_messages(codigo, text),
             response_format={"type": "json_object"},
             temperature=0,
         )
         return json.loads(resp.choices[0].message.content)
 
-    # --- full pipeline for one PDF ---
-    def extract_project(self, pdf_path: str) -> Projeto:
-        codigo = _codigo_from_filename(pdf_path)
-        # cheap path first: use embedded text (no OCR call) when the PDF is digital;
-        # fall back to OCR only for scanned PDFs with little/no extractable text.
-        text, num_pages = self.pdf_text(pdf_path)
-        if len(text.strip()) >= MIN_PDF_TEXT_CHARS:
-            source = "pdf-text"
-        else:
-            text, num_pages = self.ocr_pdf(pdf_path)
-            source = "ocr"
-        raw = self.extract_fields(codigo, text)
-
+    # --- post-process a raw extraction dict into a validated Projeto ---
+    def finalize(self, codigo: str, raw: dict, arquivo: str,
+                 num_pages: int, source: str) -> Projeto:
         raw["codigo"] = codigo  # filename is authoritative
         # Defensive: 'equipe' must be real people. Drop entries without a name
         # (usually mis-classified work-plan/task titles) -> they belong to cronograma.
@@ -159,7 +162,7 @@ class ProjectExtractor:
                 if isinstance(m, dict) and (m.get("nome") or "").strip()
             ]
         raw["_meta"] = {
-            "arquivo": os.path.basename(pdf_path),
+            "arquivo": arquivo,
             "paginas": num_pages,
             "extraido_em": datetime.now(timezone.utc).isoformat(),
             "modelo": self.chat_model,
@@ -169,3 +172,10 @@ class ProjectExtractor:
         projeto = Projeto.model_validate(raw)
         projeto.meta.campos_ausentes = _missing_fields(projeto)
         return projeto
+
+    # --- full synchronous pipeline for one PDF ---
+    def extract_project(self, pdf_path: str) -> Projeto:
+        codigo = _codigo_from_filename(pdf_path)
+        text, num_pages, source = self.text_for(pdf_path)
+        raw = self.extract_fields(codigo, text)
+        return self.finalize(codigo, raw, os.path.basename(pdf_path), num_pages, source)

--- a/src/agent_sigpesq/extraction/mistral_extractor.py
+++ b/src/agent_sigpesq/extraction/mistral_extractor.py
@@ -1,0 +1,128 @@
+"""
+ProjectExtractor: turn a SIGPESQ project PDF into a validated `Projeto` JSON
+using the Mistral API (OCR + chat in JSON mode).
+"""
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from typing import List, Optional, Tuple
+
+from mistralai import Mistral
+
+from .schema import Projeto, JSON_TEMPLATE
+
+OCR_MODEL = "mistral-ocr-latest"
+CHAT_MODEL = "mistral-large-latest"
+MAX_MARKDOWN_CHARS = 180_000  # keep the prompt within the model context window
+
+SYSTEM_PROMPT = (
+    "Você extrai dados estruturados de projetos de pesquisa a partir do texto "
+    "de um PDF. Responda SOMENTE com um objeto JSON válido, em português, no "
+    "formato pedido. Regras: use exatamente as chaves do modelo; se uma "
+    "informação não estiver no texto, use null (ou lista vazia) — NUNCA invente "
+    "dados; datas no formato ISO (YYYY-MM-DD ou YYYY-MM); valores numéricos sem "
+    "símbolo de moeda (ex.: 25000.00)."
+)
+
+
+def _codigo_from_filename(path: str) -> str:
+    """'…/PJ_9760.pdf' -> 'PJ 9760' (authoritative project code from the filename)."""
+    stem = os.path.splitext(os.path.basename(path))[0]
+    return stem.replace("_", " ").strip()
+
+
+def _missing_fields(p: Projeto) -> List[str]:
+    """List the important fields that came back empty (for `_meta.campos_ausentes`)."""
+    missing: List[str] = []
+    if not p.titulo:
+        missing.append("titulo")
+    if not p.descricao:
+        missing.append("descricao")
+    if not p.area_conhecimento:
+        missing.append("area_conhecimento")
+    if not p.coordenador.nome:
+        missing.append("coordenador.nome")
+    if not p.coordenador.email:
+        missing.append("coordenador.email")
+    if not p.equipe:
+        missing.append("equipe")
+    if not p.datas.inicio:
+        missing.append("datas.inicio")
+    if not p.datas.fim:
+        missing.append("datas.fim")
+    if not p.cronograma:
+        missing.append("cronograma")
+    if p.financiamento.valor_total is None and not p.financiamento.fontes:
+        missing.append("financiamento")
+    if not p.objetivos.geral:
+        missing.append("objetivos.geral")
+    return missing
+
+
+class ProjectExtractor:
+    def __init__(self, api_key: Optional[str] = None,
+                 ocr_model: str = OCR_MODEL, chat_model: str = CHAT_MODEL):
+        api_key = api_key or os.getenv("MISTRAL_KEY") or os.getenv("MISTRAL_API_KEY")
+        if not api_key:
+            raise ValueError("Set MISTRAL_KEY (or MISTRAL_API_KEY) in the environment/.env")
+        self.client = Mistral(api_key=api_key)
+        self.ocr_model = ocr_model
+        self.chat_model = chat_model
+
+    # --- step 1: OCR the PDF to markdown ---
+    def ocr_pdf(self, pdf_path: str) -> Tuple[str, int]:
+        """Upload the PDF, OCR it, and return (markdown_text, num_pages)."""
+        with open(pdf_path, "rb") as f:
+            content = f.read()
+        uploaded = self.client.files.upload(
+            file={"file_name": os.path.basename(pdf_path), "content": content},
+            purpose="ocr",
+        )
+        signed = self.client.files.get_signed_url(file_id=uploaded.id)
+        resp = self.client.ocr.process(
+            model=self.ocr_model,
+            document={"type": "document_url", "document_url": signed.url},
+        )
+        pages = resp.pages or []
+        markdown = "\n\n".join((pg.markdown or "") for pg in pages)
+        return markdown, len(pages)
+
+    # --- step 2: structured extraction via chat (JSON mode) ---
+    def extract_fields(self, codigo: str, markdown: str) -> dict:
+        text = markdown[:MAX_MARKDOWN_CHARS]
+        user_prompt = (
+            f"Código do projeto (use exatamente este valor em 'codigo'): {codigo}\n\n"
+            f"Formato JSON esperado (modelo das chaves):\n"
+            f"{json.dumps(JSON_TEMPLATE, ensure_ascii=False, indent=2)}\n\n"
+            f"Texto do PDF do projeto (markdown do OCR):\n\"\"\"\n{text}\n\"\"\""
+        )
+        resp = self.client.chat.complete(
+            model=self.chat_model,
+            messages=[
+                {"role": "system", "content": SYSTEM_PROMPT},
+                {"role": "user", "content": user_prompt},
+            ],
+            response_format={"type": "json_object"},
+            temperature=0,
+        )
+        return json.loads(resp.choices[0].message.content)
+
+    # --- full pipeline for one PDF ---
+    def extract_project(self, pdf_path: str) -> Projeto:
+        codigo = _codigo_from_filename(pdf_path)
+        markdown, num_pages = self.ocr_pdf(pdf_path)
+        raw = self.extract_fields(codigo, markdown)
+
+        raw["codigo"] = codigo  # filename is authoritative
+        raw["_meta"] = {
+            "arquivo": os.path.basename(pdf_path),
+            "paginas": num_pages,
+            "extraido_em": datetime.now(timezone.utc).isoformat(),
+            "modelo": self.chat_model,
+            "campos_ausentes": [],
+        }
+        projeto = Projeto.model_validate(raw)
+        projeto.meta.campos_ausentes = _missing_fields(projeto)
+        return projeto

--- a/src/agent_sigpesq/extraction/mistral_extractor.py
+++ b/src/agent_sigpesq/extraction/mistral_extractor.py
@@ -20,10 +20,21 @@ MAX_MARKDOWN_CHARS = 180_000  # keep the prompt within the model context window
 SYSTEM_PROMPT = (
     "Você extrai dados estruturados de projetos de pesquisa a partir do texto "
     "de um PDF. Responda SOMENTE com um objeto JSON válido, em português, no "
-    "formato pedido. Regras: use exatamente as chaves do modelo; se uma "
+    "formato pedido. Regras gerais: use exatamente as chaves do modelo; se uma "
     "informação não estiver no texto, use null (ou lista vazia) — NUNCA invente "
     "dados; datas no formato ISO (YYYY-MM-DD ou YYYY-MM); valores numéricos sem "
-    "símbolo de moeda (ex.: 25000.00)."
+    "símbolo de moeda (ex.: 25000.00).\n"
+    "Regras para 'equipe': liste APENAS pessoas reais identificadas por NOME "
+    "próprio. O campo 'funcao' é o PAPEL da pessoa (ex.: Coordenador, "
+    "Pesquisador, Bolsista, Colaborador, Estudante/Orientando) — NUNCA um título "
+    "de plano de trabalho, subprojeto, atividade ou tarefa. Se um item não tiver "
+    "nome de pessoa, NÃO o inclua em 'equipe'.\n"
+    "Regras para 'cronograma': títulos de planos de trabalho de estudantes, "
+    "subprojetos, etapas, atividades ou tarefas pertencem ao 'cronograma' (campo "
+    "'atividade'), e NÃO a 'equipe'.\n"
+    "Regras para 'coordenador': é o responsável/coordenador do projeto; extraia "
+    "o nome mesmo que apareça em seções de identificação, assinatura ou "
+    "responsável técnico."
 )
 
 
@@ -116,6 +127,14 @@ class ProjectExtractor:
         raw = self.extract_fields(codigo, markdown)
 
         raw["codigo"] = codigo  # filename is authoritative
+        # Defensive: 'equipe' must be real people. Drop entries without a name
+        # (usually mis-classified work-plan/task titles) -> they belong to cronograma.
+        equipe = raw.get("equipe")
+        if isinstance(equipe, list):
+            raw["equipe"] = [
+                m for m in equipe
+                if isinstance(m, dict) and (m.get("nome") or "").strip()
+            ]
         raw["_meta"] = {
             "arquivo": os.path.basename(pdf_path),
             "paginas": num_pages,

--- a/src/agent_sigpesq/extraction/schema.py
+++ b/src/agent_sigpesq/extraction/schema.py
@@ -59,6 +59,7 @@ class Meta(BaseModel):
     paginas: Optional[int] = None
     extraido_em: Optional[str] = None
     modelo: Optional[str] = None
+    fonte_texto: Optional[str] = None   # "pdf-text" (local) or "ocr"
     campos_ausentes: List[str] = Field(default_factory=list)
 
 

--- a/src/agent_sigpesq/extraction/schema.py
+++ b/src/agent_sigpesq/extraction/schema.py
@@ -1,0 +1,101 @@
+"""
+Pydantic schema for a research project extracted from a SIGPESQ project PDF.
+
+All content fields are Optional: whatever the PDF does not contain is left as
+``None`` (or an empty list) -- the extractor never invents data. `Meta` is filled
+by our code (not the model) for provenance.
+"""
+from __future__ import annotations
+
+from typing import List, Optional
+from pydantic import BaseModel, Field
+
+
+class Coordenador(BaseModel):
+    nome: Optional[str] = None
+    email: Optional[str] = None
+    campus: Optional[str] = None
+    titulacao: Optional[str] = None
+
+
+class MembroEquipe(BaseModel):
+    nome: Optional[str] = None
+    funcao: Optional[str] = None
+    instituicao: Optional[str] = None
+    carga_horaria_semanal: Optional[float] = None
+
+
+class Datas(BaseModel):
+    inicio: Optional[str] = None          # ISO date "YYYY-MM-DD" when available
+    fim: Optional[str] = None
+    duracao_meses: Optional[int] = None
+
+
+class CronogramaItem(BaseModel):
+    atividade: Optional[str] = None
+    inicio: Optional[str] = None          # "YYYY-MM" or "YYYY-MM-DD"
+    fim: Optional[str] = None
+
+
+class FonteFinanciamento(BaseModel):
+    fonte: Optional[str] = None
+    valor: Optional[float] = None
+    tipo: Optional[str] = None
+
+
+class Financiamento(BaseModel):
+    valor_total: Optional[float] = None
+    moeda: str = "BRL"
+    fontes: List[FonteFinanciamento] = Field(default_factory=list)
+
+
+class Objetivos(BaseModel):
+    geral: Optional[str] = None
+    especificos: List[str] = Field(default_factory=list)
+
+
+class Meta(BaseModel):
+    arquivo: str
+    paginas: Optional[int] = None
+    extraido_em: Optional[str] = None
+    modelo: Optional[str] = None
+    campos_ausentes: List[str] = Field(default_factory=list)
+
+
+class Projeto(BaseModel):
+    codigo: Optional[str] = None
+    titulo: Optional[str] = None
+    descricao: Optional[str] = None
+    palavras_chave: List[str] = Field(default_factory=list)
+    area_conhecimento: Optional[str] = None
+    linha_pesquisa: Optional[str] = None
+    objetivos: Objetivos = Field(default_factory=Objetivos)
+    coordenador: Coordenador = Field(default_factory=Coordenador)
+    equipe: List[MembroEquipe] = Field(default_factory=list)
+    datas: Datas = Field(default_factory=Datas)
+    cronograma: List[CronogramaItem] = Field(default_factory=list)
+    financiamento: Financiamento = Field(default_factory=Financiamento)
+    meta: Meta = Field(..., alias="_meta")
+
+    model_config = {"populate_by_name": True}
+
+
+# The JSON shape shown to the extraction model (keeps the LLM output aligned with the schema).
+JSON_TEMPLATE = {
+    "codigo": "PJ 9760",
+    "titulo": "string",
+    "descricao": "string",
+    "palavras_chave": ["string"],
+    "area_conhecimento": "string ou null",
+    "linha_pesquisa": "string ou null",
+    "objetivos": {"geral": "string ou null", "especificos": ["string"]},
+    "coordenador": {"nome": "string ou null", "email": "string ou null",
+                    "campus": "string ou null", "titulacao": "string ou null"},
+    "equipe": [{"nome": "string", "funcao": "string ou null",
+                "instituicao": "string ou null", "carga_horaria_semanal": "number ou null"}],
+    "datas": {"inicio": "YYYY-MM-DD ou null", "fim": "YYYY-MM-DD ou null",
+              "duracao_meses": "number ou null"},
+    "cronograma": [{"atividade": "string", "inicio": "YYYY-MM ou null", "fim": "YYYY-MM ou null"}],
+    "financiamento": {"valor_total": "number ou null", "moeda": "BRL",
+                      "fontes": [{"fonte": "string", "valor": "number ou null", "tipo": "string ou null"}]},
+}

--- a/src/agent_sigpesq/strategies/__init__.py
+++ b/src/agent_sigpesq/strategies/__init__.py
@@ -9,10 +9,12 @@ from .report_download_strategy import ReportDownloadStrategy
 from .research_groups_strategy import ResearchGroupsDownloadStrategy
 from .projects_strategy import ProjectsDownloadStrategy
 from .advisorships_strategy import AdvisorshipsDownloadStrategy
+from .project_files_strategy import ProjectFilesDownloadStrategy
 
 __all__ = [
     "ReportDownloadStrategy",
     "ResearchGroupsDownloadStrategy",
     "ProjectsDownloadStrategy",
     "AdvisorshipsDownloadStrategy",
+    "ProjectFilesDownloadStrategy",
 ]

--- a/src/agent_sigpesq/strategies/project_files_strategy.py
+++ b/src/agent_sigpesq/strategies/project_files_strategy.py
@@ -19,6 +19,7 @@ already being authenticated. It never logs in again (the portal rate-limits logi
 """
 from __future__ import annotations
 
+import glob
 import os
 import re
 from playwright.async_api import Page, TimeoutError as PlaywrightTimeoutError
@@ -101,9 +102,10 @@ class ProjectFilesDownloadStrategy(BasePlaywrightStrategy):
                     return ok > 0
                 done += 1
                 code = await self._row_code(page, i, page_num)
-                # resumable: skip projects whose PDF is already on disk
-                if self.skip_existing and os.path.exists(
-                        os.path.join(target_subdir, f"{_safe_name(code)}.pdf")):
+                # resumable: skip projects whose file is already on disk (any
+                # extension -- the "Projeto" file may be .pdf, .doc, .odt, ...)
+                if self.skip_existing and glob.glob(
+                        os.path.join(target_subdir, f"{_safe_name(code)}.*")):
                     ok += 1
                     continue
                 if await self._download_one(page, i, code, target_subdir):

--- a/src/agent_sigpesq/strategies/project_files_strategy.py
+++ b/src/agent_sigpesq/strategies/project_files_strategy.py
@@ -1,0 +1,204 @@
+"""
+Strategy for downloading the per-project PDF file ("Projeto") of every research
+project listed under Diretoria -> Projetos -> do Campus.
+
+Path (discovered on the SIGPESQ portal, all within a SINGLE logged-in session):
+  /web/projeto/listaUnidade.aspx
+    -> grid #ContentPlaceHolder_gvwLista (10 projects per page, paginated)
+       -> per row: click "Resumo do Projeto" button
+          (#ContentPlaceHolder_gvwLista_btnResumoProjeto_<i>)
+          opens the modal #ContentPlaceHolder_ModalConsultaProjeto (in-page, no navigation)
+          -> the modal's "Arquivos" table (rptArquivo) has a download link labeled "Projeto"
+             (#ContentPlaceHolder_ModalConsultaProjeto_..._rptArquivo_Download_0)
+             -> clicking it (__doPostBack) streams the project PDF
+       -> "Fechar" (#ContentPlaceHolder_ModalConsultaProjeto_btnModal_Fechar) closes the modal
+    -> pager: __doPostBack('ctl00$ContentPlaceHolder$gvwLista', 'Page$<N>')
+
+This strategy re-navigates to the list page itself; it relies only on the page
+already being authenticated. It never logs in again (the portal rate-limits logins).
+"""
+from __future__ import annotations
+
+import os
+import re
+from playwright.async_api import Page, TimeoutError as PlaywrightTimeoutError
+from .report_download_strategy import BasePlaywrightStrategy
+
+BASE = "https://sigpesq.ifes.edu.br/web"
+LIST_URL = f"{BASE}/projeto/listaUnidade.aspx"
+
+GRID = "#ContentPlaceHolder_gvwLista"
+RESUMO_BTN = "#ContentPlaceHolder_gvwLista_btnResumoProjeto_{i}"
+MODAL = "#ContentPlaceHolder_ModalConsultaProjeto"
+MODAL_CLOSE = "#ContentPlaceHolder_ModalConsultaProjeto_btnModal_Fechar"
+# download links inside the modal's "Arquivos" repeater
+MODAL_FILE_LINKS = "[id*='ModalConsultaProjeto'][id*='rptArquivo_Download']"
+
+
+def _safe_name(text: str) -> str:
+    """Turn a project code like 'PJ 9760' into a filesystem-safe stem 'PJ_9760'."""
+    return re.sub(r"[^A-Za-z0-9._-]+", "_", (text or "").strip()).strip("_") or "projeto"
+
+
+class ProjectFilesDownloadStrategy(BasePlaywrightStrategy):
+    """
+    Downloads the "Projeto" PDF of every campus research project via the
+    Resumo modal, iterating all grid pages. Single login (reuses the page).
+    """
+
+    def __init__(self, limit: int | None = None, file_label: str = "Projeto"):
+        """
+        Args:
+            limit: max number of projects to process (None = all). Handy for testing.
+            file_label: the link text inside the Arquivos table to download
+                        ("Projeto" = the main project PDF).
+        """
+        self.limit = limit
+        self.file_label = file_label
+
+    def get_category_name(self) -> str:
+        return "Research Project Files"
+
+    def get_button_id(self) -> str:
+        # No single button; per-row Resumo buttons are used instead.
+        return "ContentPlaceHolder_gvwLista_btnResumoProjeto_0"
+
+    async def download(self, page: Page, reports_dir: str) -> bool:
+        print(f"Processing {self.get_category_name()}...")
+        target_subdir = os.path.join(reports_dir, "project_files")
+        os.makedirs(target_subdir, exist_ok=True)
+
+        try:
+            await page.goto(LIST_URL)
+            await page.wait_for_load_state("networkidle")
+            await page.wait_for_selector(GRID, timeout=15000)
+        except Exception as e:
+            print(f"Could not open project list: {e}")
+            return False
+
+        total, ok, done = await self._read_total(page), 0, 0
+        print(f"Total projects reported by portal: {total or 'unknown'}")
+
+        page_num = 1
+        while True:
+            # rows present on the current grid page
+            row_count = await page.locator(f"{GRID} a[id*='btnResumoProjeto']").count()
+            if row_count == 0:
+                print(f"No project rows on page {page_num}; stopping.")
+                break
+
+            print(f"--- Grid page {page_num}: {row_count} projects ---")
+            for i in range(row_count):
+                if self.limit is not None and done >= self.limit:
+                    print(f"Reached limit={self.limit}; stopping.")
+                    return ok > 0
+                done += 1
+                code = await self._row_code(page, i)
+                if await self._download_one(page, i, code, target_subdir):
+                    ok += 1
+                # after Fechar the grid is re-rendered on the same page; continue
+
+            # advance to next grid page, if any
+            if not await self._go_to_page(page, page_num + 1):
+                break
+            page_num += 1
+
+        print(f"Done. Downloaded {ok} project file(s) into {target_subdir}.")
+        return ok > 0
+
+    async def _download_one(self, page: Page, i: int, code: str, target_subdir: str) -> bool:
+        """Open the Resumo modal for row i, download the '<file_label>' PDF, close the modal."""
+        try:
+            await page.click(RESUMO_BTN.format(i=i))
+            # the modal opens for any project (even drafts); its "Fechar" button is a
+            # reliable "modal is open" signal (the outer modal div has no bounding box).
+            await page.wait_for_selector(MODAL_CLOSE, state="visible", timeout=12000)
+        except PlaywrightTimeoutError:
+            print(f"[{code}] Resumo modal did not open; skipping.")
+            await self._close_modal(page)
+            return False
+        except Exception as e:
+            print(f"[{code}] error opening modal: {e}")
+            await self._close_modal(page)
+            return False
+
+        # drafts have an empty Arquivos table -> no file links -> skip fast (no long wait)
+        if await page.locator(MODAL_FILE_LINKS).count() == 0:
+            print(f"[{code}] no files in Arquivos (likely a draft); skipping.")
+            await self._close_modal(page)
+            return False
+
+        # pick the link labeled with file_label (e.g. "Projeto"); fall back to first file
+        link = page.locator(MODAL_FILE_LINKS, has_text=self.file_label).first
+        if await link.count() == 0:
+            link = page.locator(MODAL_FILE_LINKS).first
+
+        try:
+            async with page.expect_download(timeout=60000) as dl_info:
+                await link.click()
+            download = await dl_info.value
+            suggested = download.suggested_filename or "projeto.pdf"
+            ext = os.path.splitext(suggested)[1] or ".pdf"
+            dest = os.path.join(target_subdir, f"{_safe_name(code)}{ext}")
+            if os.path.exists(dest):
+                os.remove(dest)
+            await download.save_as(dest)
+            print(f"[{code}] saved -> {dest}")
+            return True
+        except Exception as e:
+            print(f"[{code}] download failed: {e}")
+            return False
+        finally:
+            await self._close_modal(page)
+
+    async def _close_modal(self, page: Page):
+        try:
+            if await page.locator(MODAL_CLOSE).count() > 0 and await page.is_visible(MODAL_CLOSE):
+                await page.click(MODAL_CLOSE)
+                await page.wait_for_load_state("networkidle")
+        except Exception:
+            pass
+
+    async def _go_to_page(self, page: Page, n: int) -> bool:
+        """Click the grid pager for page n. Returns False if that page link is absent."""
+        # pager links live in the .gvwPager row; match the exact page-number text
+        link = page.locator(".gvwPager a").filter(has_text=re.compile(rf"^\s*{n}\s*$")).first
+        if await link.count() == 0:
+            return False
+        try:
+            await link.click()
+            await page.wait_for_load_state("networkidle")
+            await page.wait_for_selector(GRID, timeout=15000)
+            return True
+        except Exception as e:
+            print(f"Could not go to grid page {n}: {e}")
+            return False
+
+    async def _row_code(self, page: Page, i: int) -> str:
+        """Read the project code (e.g. 'PJ 9760') from row i for use as the filename."""
+        try:
+            code = await page.evaluate(
+                """(i) => {
+                    const btns = document.querySelectorAll("#ContentPlaceHolder_gvwLista a[id*='btnResumoProjeto']");
+                    const tr = btns[i] && btns[i].closest('tr');
+                    if (!tr) return null;
+                    for (const td of tr.querySelectorAll('td')) {
+                        const m = (td.innerText||'').match(/PJ\\s*\\d+/);
+                        if (m) return m[0];
+                    }
+                    return null;
+                }""",
+                i,
+            )
+            return code or f"row{i}"
+        except Exception:
+            return f"row{i}"
+
+    async def _read_total(self, page: Page):
+        """Parse 'Mostrando de X até Y de N registro(s)' to get the total count."""
+        try:
+            txt = await page.locator(".gvwPager").first.inner_text()
+            m = re.search(r"de\s+(\d+)\s+registro", txt)
+            return int(m.group(1)) if m else None
+        except Exception:
+            return None

--- a/src/agent_sigpesq/strategies/project_files_strategy.py
+++ b/src/agent_sigpesq/strategies/project_files_strategy.py
@@ -100,7 +100,7 @@ class ProjectFilesDownloadStrategy(BasePlaywrightStrategy):
                     print(f"Reached limit={self.limit}; stopping.")
                     return ok > 0
                 done += 1
-                code = await self._row_code(page, i)
+                code = await self._row_code(page, i, page_num)
                 # resumable: skip projects whose PDF is already on disk
                 if self.skip_existing and os.path.exists(
                         os.path.join(target_subdir, f"{_safe_name(code)}.pdf")):
@@ -216,8 +216,12 @@ class ProjectFilesDownloadStrategy(BasePlaywrightStrategy):
         print(f"Could not load rows for grid page {n} after retries.")
         return False
 
-    async def _row_code(self, page: Page, i: int) -> str:
-        """Read the project code (e.g. 'PJ 9760') from row i for use as the filename."""
+    async def _row_code(self, page: Page, i: int, page_num: int = 0) -> str:
+        """Read the project code (e.g. 'PJ 9760') from row i for use as the filename.
+
+        Falls back to a page-unique placeholder if the code can't be read, so
+        unreadable rows on different pages never collide on the same filename.
+        """
         try:
             code = await page.evaluate(
                 """(i) => {
@@ -232,9 +236,9 @@ class ProjectFilesDownloadStrategy(BasePlaywrightStrategy):
                 }""",
                 i,
             )
-            return code or f"row{i}"
+            return code or f"unknown_p{page_num}r{i}"
         except Exception:
-            return f"row{i}"
+            return f"unknown_p{page_num}r{i}"
 
     async def _read_total(self, page: Page):
         """Parse 'Mostrando de X até Y de N registro(s)' to get the total count."""

--- a/src/agent_sigpesq/strategies/project_files_strategy.py
+++ b/src/agent_sigpesq/strategies/project_files_strategy.py
@@ -77,7 +77,10 @@ class ProjectFilesDownloadStrategy(BasePlaywrightStrategy):
             return False
 
         total, ok, done = await self._read_total(page), 0, 0
-        print(f"Total projects reported by portal: {total or 'unknown'}")
+        # total pages = ceil(total / rows_per_page); the portal shows 10 rows/page
+        max_pages = (total + 9) // 10 if total else None
+        print(f"Total projects reported by portal: {total or 'unknown'}"
+              + (f" ({max_pages} pages)" if max_pages else ""))
 
         page_num = 1
         while True:
@@ -98,7 +101,9 @@ class ProjectFilesDownloadStrategy(BasePlaywrightStrategy):
                     ok += 1
                 # after Fechar the grid is re-rendered on the same page; continue
 
-            # advance to next grid page, if any
+            # advance to next grid page, if any (bounded by the total page count)
+            if max_pages is not None and page_num >= max_pages:
+                break
             if not await self._go_to_page(page, page_num + 1):
                 break
             page_num += 1
@@ -160,13 +165,17 @@ class ProjectFilesDownloadStrategy(BasePlaywrightStrategy):
             pass
 
     async def _go_to_page(self, page: Page, n: int) -> bool:
-        """Click the grid pager for page n. Returns False if that page link is absent."""
-        # pager links live in the .gvwPager row; match the exact page-number text
-        link = page.locator(".gvwPager a").filter(has_text=re.compile(rf"^\s*{n}\s*$")).first
-        if await link.count() == 0:
-            return False
+        """Go to grid page n via the GridView postback.
+
+        The portal's pager is windowed (it only renders a handful of page numbers
+        plus 'Last'), so clicking a numbered link fails past the window. The
+        GridView accepts a 'Page$N' command for any N, so we invoke the postback
+        directly instead of relying on a visible link.
+        """
         try:
-            await link.click()
+            await page.evaluate(
+                "(n) => __doPostBack('ctl00$ContentPlaceHolder$gvwLista', 'Page$' + n)", n
+            )
             await page.wait_for_load_state("networkidle")
             await page.wait_for_selector(GRID, timeout=15000)
             return True

--- a/src/agent_sigpesq/strategies/project_files_strategy.py
+++ b/src/agent_sigpesq/strategies/project_files_strategy.py
@@ -219,26 +219,29 @@ class ProjectFilesDownloadStrategy(BasePlaywrightStrategy):
     async def _row_code(self, page: Page, i: int, page_num: int = 0) -> str:
         """Read the project code (e.g. 'PJ 9760') from row i for use as the filename.
 
-        Falls back to a page-unique placeholder if the code can't be read, so
+        Retries a few times (the cell text can be momentarily empty during the
+        modal-heavy flow), then falls back to a page-unique placeholder so
         unreadable rows on different pages never collide on the same filename.
         """
-        try:
-            code = await page.evaluate(
-                """(i) => {
-                    const btns = document.querySelectorAll("#ContentPlaceHolder_gvwLista a[id*='btnResumoProjeto']");
-                    const tr = btns[i] && btns[i].closest('tr');
-                    if (!tr) return null;
-                    for (const td of tr.querySelectorAll('td')) {
-                        const m = (td.innerText||'').match(/PJ\\s*\\d+/);
-                        if (m) return m[0];
-                    }
-                    return null;
-                }""",
-                i,
-            )
-            return code or f"unknown_p{page_num}r{i}"
-        except Exception:
-            return f"unknown_p{page_num}r{i}"
+        js = """(i) => {
+            const btns = document.querySelectorAll("#ContentPlaceHolder_gvwLista a[id*='btnResumoProjeto']");
+            const tr = btns[i] && btns[i].closest('tr');
+            if (!tr) return null;
+            for (const td of tr.querySelectorAll('td')) {
+                const m = (td.innerText||'').match(/PJ\\s*\\d+/);
+                if (m) return m[0];
+            }
+            return null;
+        }"""
+        for attempt in range(3):
+            try:
+                code = await page.evaluate(js, i)
+            except Exception:
+                code = None
+            if code:
+                return code
+            await page.wait_for_timeout(400)  # cell may still be rendering
+        return f"unknown_p{page_num}r{i}"
 
     async def _read_total(self, page: Page):
         """Parse 'Mostrando de X até Y de N registro(s)' to get the total count."""

--- a/src/agent_sigpesq/strategies/project_files_strategy.py
+++ b/src/agent_sigpesq/strategies/project_files_strategy.py
@@ -46,15 +46,19 @@ class ProjectFilesDownloadStrategy(BasePlaywrightStrategy):
     Resumo modal, iterating all grid pages. Single login (reuses the page).
     """
 
-    def __init__(self, limit: int | None = None, file_label: str = "Projeto"):
+    def __init__(self, limit: int | None = None, file_label: str = "Projeto",
+                 skip_existing: bool = True):
         """
         Args:
             limit: max number of projects to process (None = all). Handy for testing.
             file_label: the link text inside the Arquivos table to download
                         ("Projeto" = the main project PDF).
+            skip_existing: if True, projects whose PDF is already on disk are skipped
+                           (makes a re-run resumable, e.g. after a mid-run stop).
         """
         self.limit = limit
         self.file_label = file_label
+        self.skip_existing = skip_existing
 
     def get_category_name(self) -> str:
         return "Research Project Files"
@@ -97,6 +101,11 @@ class ProjectFilesDownloadStrategy(BasePlaywrightStrategy):
                     return ok > 0
                 done += 1
                 code = await self._row_code(page, i)
+                # resumable: skip projects whose PDF is already on disk
+                if self.skip_existing and os.path.exists(
+                        os.path.join(target_subdir, f"{_safe_name(code)}.pdf")):
+                    ok += 1
+                    continue
                 if await self._download_one(page, i, code, target_subdir):
                     ok += 1
                 # after Fechar the grid is re-rendered on the same page; continue
@@ -104,6 +113,16 @@ class ProjectFilesDownloadStrategy(BasePlaywrightStrategy):
             # advance to next grid page, if any (bounded by the total page count)
             if max_pages is not None and page_num >= max_pages:
                 break
+            # let the last modal-close postback settle (pager back on page_num) so the
+            # next click isn't issued against a still-updating grid
+            try:
+                await page.wait_for_function(
+                    "(n) => { const s = document.querySelector('.gvwPager span');"
+                    " return !!s && s.textContent.trim() === String(n); }",
+                    arg=page_num, timeout=10000,
+                )
+            except Exception:
+                pass
             if not await self._go_to_page(page, page_num + 1):
                 break
             page_num += 1
@@ -165,23 +184,37 @@ class ProjectFilesDownloadStrategy(BasePlaywrightStrategy):
             pass
 
     async def _go_to_page(self, page: Page, n: int) -> bool:
-        """Go to grid page n via the GridView postback.
+        """Go to grid page n by clicking its pager link, matched by postback href.
 
-        The portal's pager is windowed (it only renders a handful of page numbers
-        plus 'Last'), so clicking a numbered link fails past the window. The
-        GridView accepts a 'Page$N' command for any N, so we invoke the postback
-        directly instead of relying on a visible link.
+        The pager is windowed: it renders a block of numbers plus a '...' forward
+        link and 'Último'. Matching by visible text misses the '...' link at block
+        boundaries, so we match by the postback target in the href ('Page$N'),
+        which also covers '...'. Navigating sequentially, a link for page N always
+        exists (a numeric one inside the block, or '...' at the boundary).
         """
-        try:
-            await page.evaluate(
-                "(n) => __doPostBack('ctl00$ContentPlaceHolder$gvwLista', 'Page$' + n)", n
-            )
-            await page.wait_for_load_state("networkidle")
-            await page.wait_for_selector(GRID, timeout=15000)
-            return True
-        except Exception as e:
-            print(f"Could not go to grid page {n}: {e}")
-            return False
+        selector = f".gvwPager a[href*=\"Page${n}'\"]"
+        # A modal-close postback from the previous page can still be in flight, so a
+        # click can land on a half-rendered/empty grid. Retry the whole click, and
+        # only accept it once the pager shows page n AND the grid has project rows.
+        landed = (
+            "(n) => { const s = document.querySelector('.gvwPager span');"
+            " const rows = document.querySelectorAll("
+            "\"#ContentPlaceHolder_gvwLista a[id*='btnResumoProjeto']\").length;"
+            " return !!s && s.textContent.trim() === String(n) && rows > 0; }"
+        )
+        for _attempt in range(4):
+            link = page.locator(selector).first
+            if await link.count() == 0:
+                await page.wait_for_timeout(1000)  # pager may still be rendering
+                continue
+            try:
+                await link.click()
+                await page.wait_for_function(landed, arg=n, timeout=15000)
+                return True
+            except Exception:
+                await page.wait_for_timeout(1000)  # empty/half-rendered -> retry click
+        print(f"Could not load rows for grid page {n} after retries.")
+        return False
 
     async def _row_code(self, page: Page, i: int) -> str:
         """Read the project code (e.g. 'PJ 9760') from row i for use as the filename."""

--- a/tests/test_extraction_batch.py
+++ b/tests/test_extraction_batch.py
@@ -1,0 +1,82 @@
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("mistralai")
+
+from agent_sigpesq.extraction.batch_extractor import BatchProjectExtractor  # noqa: E402
+
+
+def _extractor():
+    ex = BatchProjectExtractor(api_key="test-key")
+    ex.client = MagicMock()
+    return ex
+
+
+class TestBatchBuild(unittest.TestCase):
+    def test_build_requests_batches_digital_skips_scanned(self):
+        ex = _extractor()
+        # digital: plenty of text; scanned: empty
+        def fake_pdf_text(path):
+            return ("x" * 1000, 5) if "digital" in path else ("", 0)
+        ex.pdf_text = fake_pdf_text
+
+        with tempfile.TemporaryDirectory() as d:
+            digital = os.path.join(d, "PJ_100_digital.pdf")
+            scanned = os.path.join(d, "PJ_200_scanned.pdf")
+            for f in (digital, scanned):
+                open(f, "wb").close()
+            jsonl, meta, skipped = ex.build_requests([digital, scanned])
+
+        lines = [ln for ln in jsonl.splitlines() if ln.strip()]
+        self.assertEqual(len(lines), 1)              # only the digital one
+        self.assertEqual(skipped, [scanned])
+        rec = json.loads(lines[0])
+        self.assertEqual(rec["custom_id"], "PJ_100_digital")
+        self.assertEqual(rec["body"]["response_format"], {"type": "json_object"})
+        self.assertIn("PJ_100_digital", meta)
+        self.assertEqual(meta["PJ_100_digital"]["fonte_texto"], "pdf-text")
+
+    def test_submit_uploads_and_creates_job(self):
+        ex = _extractor()
+        ex.client.files.upload.return_value = MagicMock(id="file-1")
+        ex.client.batch.jobs.create.return_value = MagicMock(id="job-1")
+        job_id = ex.submit('{"custom_id":"PJ_1","body":{}}\n')
+        self.assertEqual(job_id, "job-1")
+        ex.client.files.upload.assert_called_once()
+        kwargs = ex.client.batch.jobs.create.call_args.kwargs
+        self.assertEqual(kwargs["endpoint"], "/v1/chat/completions")
+        self.assertEqual(kwargs["input_files"], ["file-1"])
+
+    def test_collect_results_writes_json(self):
+        ex = _extractor()
+        chat_body = {"choices": [{"message": {"content": json.dumps({"titulo": "T"})}}]}
+        out_line = json.dumps({"custom_id": "PJ_100",
+                               "response": {"status_code": 200, "body": chat_body}})
+        ex.client.files.download.return_value = MagicMock(text=out_line + "\n")
+        job = MagicMock(output_file="out-file-1")
+        meta = {"PJ_100": {"codigo": "PJ 100", "arquivo": "PJ_100.pdf",
+                           "paginas": 3, "fonte_texto": "pdf-text"}}
+
+        with tempfile.TemporaryDirectory() as out:
+            written, errors = ex.collect_results(job, meta, out)
+            self.assertEqual((written, errors), (1, 0))
+            data = json.load(open(os.path.join(out, "PJ_100.json")))
+        self.assertEqual(data["codigo"], "PJ 100")
+        self.assertEqual(data["titulo"], "T")
+        self.assertEqual(data["_meta"]["fonte_texto"], "pdf-text")
+        self.assertEqual(data["_meta"]["paginas"], 3)
+
+    def test_collect_results_no_output_file(self):
+        ex = _extractor()
+        job = MagicMock(output_file=None)
+        with tempfile.TemporaryDirectory() as out:
+            self.assertEqual(ex.collect_results(job, {}, out), (0, 0))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_extraction_extractor.py
+++ b/tests/test_extraction_extractor.py
@@ -1,0 +1,104 @@
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("mistralai")  # extractor needs the optional mistralai dependency
+
+from agent_sigpesq.extraction.mistral_extractor import (  # noqa: E402
+    ProjectExtractor,
+    _codigo_from_filename,
+    _missing_fields,
+)
+from agent_sigpesq.extraction.schema import Projeto  # noqa: E402
+
+
+def _make_extractor_with_mock(chat_payload: dict, pages_markdown):
+    """Build a ProjectExtractor whose Mistral client is fully mocked."""
+    ex = ProjectExtractor(api_key="test-key")
+    ex.client = MagicMock()
+    ex.client.files.upload.return_value = MagicMock(id="file-123")
+    ex.client.files.get_signed_url.return_value = MagicMock(url="https://signed.example/doc")
+    ex.client.ocr.process.return_value = MagicMock(
+        pages=[MagicMock(markdown=md) for md in pages_markdown]
+    )
+    ex.client.chat.complete.return_value = MagicMock(
+        choices=[MagicMock(message=MagicMock(content=json.dumps(chat_payload)))]
+    )
+    return ex
+
+
+class TestHelpers(unittest.TestCase):
+    def test_codigo_from_filename(self):
+        self.assertEqual(_codigo_from_filename("/x/reports/PJ_9760.pdf"), "PJ 9760")
+
+    def test_missing_fields_flags_empty(self):
+        p = Projeto.model_validate({"titulo": "T", "_meta": {"arquivo": "PJ_1.pdf"}})
+        missing = _missing_fields(p)
+        self.assertNotIn("titulo", missing)
+        self.assertIn("descricao", missing)
+        self.assertIn("coordenador.nome", missing)
+        self.assertIn("equipe", missing)
+        self.assertIn("cronograma", missing)
+
+
+class TestProjectExtractor(unittest.TestCase):
+    def test_missing_api_key_raises(self):
+        with patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(ValueError):
+                ProjectExtractor(api_key=None)
+
+    def test_ocr_pdf_concatenates_pages(self):
+        ex = _make_extractor_with_mock({}, ["# Page1", "Page2 text"])
+        with tempfile.NamedTemporaryFile(suffix=".pdf") as tf:
+            tf.write(b"%PDF-1.7 dummy")
+            tf.flush()
+            md, n = ex.ocr_pdf(tf.name)
+        self.assertEqual(n, 2)
+        self.assertIn("Page1", md)
+        self.assertIn("Page2 text", md)
+        ex.client.files.upload.assert_called_once()
+        ex.client.ocr.process.assert_called_once()
+
+    def test_extract_fields_uses_json_mode(self):
+        ex = _make_extractor_with_mock({"titulo": "X"}, ["md"])
+        out = ex.extract_fields("PJ 1", "some markdown")
+        self.assertEqual(out["titulo"], "X")
+        kwargs = ex.client.chat.complete.call_args.kwargs
+        self.assertEqual(kwargs["response_format"], {"type": "json_object"})
+        self.assertEqual(kwargs["model"], ex.chat_model)
+
+    def test_extract_project_builds_validated_projeto(self):
+        payload = {
+            "titulo": "Projeto X",
+            "descricao": "Uma descrição.",
+            "coordenador": {"nome": "Fulano de Tal", "campus": "Serra"},
+            "equipe": [{"nome": "Ana", "funcao": "Bolsista"}],
+            "codigo": "WRONG",  # must be overridden by the filename
+        }
+        ex = _make_extractor_with_mock(payload, ["# Projeto", "conteudo"])
+        with tempfile.TemporaryDirectory() as d:
+            pdf = os.path.join(d, "PJ_9999.pdf")
+            with open(pdf, "wb") as f:
+                f.write(b"%PDF-1.7 dummy")
+            projeto = ex.extract_project(pdf)
+
+        self.assertEqual(projeto.codigo, "PJ 9999")          # filename authoritative
+        self.assertEqual(projeto.titulo, "Projeto X")
+        self.assertEqual(projeto.coordenador.nome, "Fulano de Tal")
+        self.assertEqual(projeto.equipe[0].nome, "Ana")
+        # _meta filled by our code
+        self.assertEqual(projeto.meta.arquivo, "PJ_9999.pdf")
+        self.assertEqual(projeto.meta.paginas, 2)
+        self.assertEqual(projeto.meta.modelo, ex.chat_model)
+        # campos_ausentes computed: datas/cronograma/financiamento missing, titulo present
+        self.assertIn("datas.inicio", projeto.meta.campos_ausentes)
+        self.assertIn("cronograma", projeto.meta.campos_ausentes)
+        self.assertNotIn("titulo", projeto.meta.campos_ausentes)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_extraction_extractor.py
+++ b/tests/test_extraction_extractor.py
@@ -99,6 +99,26 @@ class TestProjectExtractor(unittest.TestCase):
         self.assertIn("cronograma", projeto.meta.campos_ausentes)
         self.assertNotIn("titulo", projeto.meta.campos_ausentes)
 
+    def test_extract_project_drops_nameless_equipe(self):
+        # nameless entries are mis-classified work-plan/task titles -> must be dropped
+        payload = {
+            "titulo": "T",
+            "equipe": [
+                {"nome": "Maria Silva", "funcao": "Coordenadora"},
+                {"nome": None, "funcao": "Plano de trabalho do estudante 1 (PIBIC)"},
+                {"nome": "  ", "funcao": "Subprojeto X"},
+            ],
+        }
+        ex = _make_extractor_with_mock(payload, ["md"])
+        with tempfile.TemporaryDirectory() as d:
+            pdf = os.path.join(d, "PJ_9674.pdf")
+            with open(pdf, "wb") as f:
+                f.write(b"%PDF-1.7 dummy")
+            projeto = ex.extract_project(pdf)
+
+        self.assertEqual(len(projeto.equipe), 1)
+        self.assertEqual(projeto.equipe[0].nome, "Maria Silva")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_extraction_extractor.py
+++ b/tests/test_extraction_extractor.py
@@ -99,6 +99,32 @@ class TestProjectExtractor(unittest.TestCase):
         self.assertIn("cronograma", projeto.meta.campos_ausentes)
         self.assertNotIn("titulo", projeto.meta.campos_ausentes)
 
+    def test_extract_project_uses_pdf_text_and_skips_ocr(self):
+        # digital PDF: embedded text is used, OCR call is skipped (cheaper)
+        ex = _make_extractor_with_mock({"titulo": "T"}, ["should-not-be-used"])
+        ex.pdf_text = lambda p: ("x" * 1000, 5)  # plenty of embedded text
+        with tempfile.TemporaryDirectory() as d:
+            pdf = os.path.join(d, "PJ_5.pdf")
+            with open(pdf, "wb") as f:
+                f.write(b"%PDF-1.7 dummy")
+            projeto = ex.extract_project(pdf)
+
+        self.assertEqual(projeto.meta.fonte_texto, "pdf-text")
+        self.assertEqual(projeto.meta.paginas, 5)
+        ex.client.ocr.process.assert_not_called()  # no OCR call for digital PDFs
+
+    def test_extract_project_falls_back_to_ocr_when_no_text(self):
+        ex = _make_extractor_with_mock({"titulo": "T"}, ["ocr text"])
+        ex.pdf_text = lambda p: ("", 0)  # scanned PDF, no embedded text
+        with tempfile.TemporaryDirectory() as d:
+            pdf = os.path.join(d, "PJ_6.pdf")
+            with open(pdf, "wb") as f:
+                f.write(b"%PDF-1.7 dummy")
+            projeto = ex.extract_project(pdf)
+
+        self.assertEqual(projeto.meta.fonte_texto, "ocr")
+        ex.client.ocr.process.assert_called_once()
+
     def test_extract_project_drops_nameless_equipe(self):
         # nameless entries are mis-classified work-plan/task titles -> must be dropped
         payload = {

--- a/tests/test_extraction_schema.py
+++ b/tests/test_extraction_schema.py
@@ -1,0 +1,45 @@
+import unittest
+
+from agent_sigpesq.extraction.schema import Projeto, JSON_TEMPLATE
+
+
+class TestProjetoSchema(unittest.TestCase):
+    def test_minimal_payload_validates_with_defaults(self):
+        p = Projeto.model_validate({"codigo": "PJ 1", "_meta": {"arquivo": "PJ_1.pdf"}})
+        # content defaults
+        self.assertEqual(p.codigo, "PJ 1")
+        self.assertIsNone(p.titulo)
+        self.assertEqual(p.palavras_chave, [])
+        self.assertEqual(p.equipe, [])
+        self.assertIsNone(p.coordenador.nome)
+        self.assertEqual(p.financiamento.moeda, "BRL")
+        self.assertEqual(p.objetivos.especificos, [])
+
+    def test_meta_alias_roundtrip(self):
+        p = Projeto.model_validate({"_meta": {"arquivo": "PJ_1.pdf", "paginas": 3}})
+        dumped = p.model_dump(by_alias=True)
+        self.assertIn("_meta", dumped)
+        self.assertNotIn("meta", dumped)
+        self.assertEqual(dumped["_meta"]["arquivo"], "PJ_1.pdf")
+        self.assertEqual(dumped["_meta"]["paginas"], 3)
+
+    def test_nested_models_parse(self):
+        p = Projeto.model_validate({
+            "_meta": {"arquivo": "PJ_9.pdf"},
+            "equipe": [{"nome": "Ana", "funcao": "Bolsista", "carga_horaria_semanal": 12}],
+            "cronograma": [{"atividade": "Coleta", "inicio": "2026-03", "fim": "2026-05"}],
+            "financiamento": {"valor_total": 1000.0, "fontes": [{"fonte": "CNPq", "valor": 1000.0}]},
+        })
+        self.assertEqual(p.equipe[0].nome, "Ana")
+        self.assertEqual(p.equipe[0].carga_horaria_semanal, 12)
+        self.assertEqual(p.cronograma[0].atividade, "Coleta")
+        self.assertEqual(p.financiamento.fontes[0].fonte, "CNPq")
+
+    def test_json_template_has_expected_keys(self):
+        for key in ("codigo", "titulo", "descricao", "coordenador", "equipe",
+                    "datas", "cronograma", "financiamento", "objetivos"):
+            self.assertIn(key, JSON_TEMPLATE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_project_files_strategy.py
+++ b/tests/test_project_files_strategy.py
@@ -97,6 +97,25 @@ class TestProjectFilesDownloadStrategy(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(m_one.call_count, 3)
         m_go.assert_not_called()  # limit hit before advancing pages
 
+    @patch.object(ProjectFilesDownloadStrategy, "_go_to_page", new_callable=AsyncMock)
+    @patch.object(ProjectFilesDownloadStrategy, "_download_one", new_callable=AsyncMock)
+    @patch.object(ProjectFilesDownloadStrategy, "_row_code", new_callable=AsyncMock)
+    @patch.object(ProjectFilesDownloadStrategy, "_read_total", new_callable=AsyncMock)
+    async def test_skips_existing_files(self, m_total, m_code, m_one, m_go):
+        m_total.return_value = 1
+        m_code.return_value = "PJ 1"
+        m_go.return_value = False
+        self.page.locator = MagicMock(return_value=_locator(count=1))
+        # pre-create the PDF so the project is treated as already downloaded
+        sub = os.path.join(self.reports_dir, "project_files")
+        os.makedirs(sub, exist_ok=True)
+        open(os.path.join(sub, "PJ_1.pdf"), "w").close()
+
+        result = await self.strategy.download(self.page, self.reports_dir)
+
+        self.assertTrue(result)
+        m_one.assert_not_called()  # existing file -> no modal/download
+
     async def test_download_returns_false_when_list_unavailable(self):
         self.page.goto = AsyncMock(side_effect=Exception("boom"))
         result = await self.strategy.download(self.page, self.reports_dir)

--- a/tests/test_project_files_strategy.py
+++ b/tests/test_project_files_strategy.py
@@ -1,0 +1,132 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock, AsyncMock, patch
+
+from agent_sigpesq.strategies.project_files_strategy import (
+    ProjectFilesDownloadStrategy,
+    _safe_name,
+)
+
+
+class FakeDownloadInfo:
+    """Mimics Playwright's `page.expect_download()` async context manager."""
+
+    def __init__(self, download):
+        self._download = download
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    @property
+    def value(self):
+        async def _resolve():
+            return self._download
+        return _resolve()
+
+
+def _locator(count=1, inner_text=""):
+    """A Locator mock where `.first` returns itself and async calls resolve."""
+    m = MagicMock()
+    m.first = m
+    m.count = AsyncMock(return_value=count)
+    m.click = AsyncMock()
+    m.filter = MagicMock(return_value=m)
+    m.inner_text = AsyncMock(return_value=inner_text)
+    return m
+
+
+class TestSafeName(unittest.TestCase):
+    def test_code_to_stem(self):
+        self.assertEqual(_safe_name("PJ 9760"), "PJ_9760")
+
+    def test_strips_unsafe_chars(self):
+        self.assertEqual(_safe_name("PJ/97*60?"), "PJ_97_60")
+
+    def test_empty_falls_back(self):
+        self.assertEqual(_safe_name("   "), "projeto")
+
+
+class TestProjectFilesDownloadStrategy(unittest.IsolatedAsyncioTestCase):
+    def setUp(self):
+        self.strategy = ProjectFilesDownloadStrategy()
+        self.reports_dir = tempfile.mkdtemp()
+        self.page = MagicMock()
+        self.page.goto = AsyncMock()
+        self.page.wait_for_load_state = AsyncMock()
+        self.page.wait_for_selector = AsyncMock()
+        self.page.click = AsyncMock()
+        self.page.is_visible = AsyncMock(return_value=True)
+        # default: grid row-count locator returns 10 rows
+        self.page.locator = MagicMock(return_value=_locator(count=10))
+
+    # ---- orchestration ----
+
+    @patch.object(ProjectFilesDownloadStrategy, "_go_to_page", new_callable=AsyncMock)
+    @patch.object(ProjectFilesDownloadStrategy, "_download_one", new_callable=AsyncMock)
+    @patch.object(ProjectFilesDownloadStrategy, "_row_code", new_callable=AsyncMock)
+    @patch.object(ProjectFilesDownloadStrategy, "_read_total", new_callable=AsyncMock)
+    async def test_iterates_all_pages(self, m_total, m_code, m_one, m_go):
+        m_total.return_value = 20
+        m_code.return_value = "PJ 1"
+        m_one.return_value = True
+        m_go.side_effect = [True, False]  # page1 -> page2 -> stop
+
+        result = await self.strategy.download(self.page, self.reports_dir)
+
+        self.assertTrue(result)
+        self.assertEqual(m_one.call_count, 20)  # 10 rows x 2 pages
+
+    @patch.object(ProjectFilesDownloadStrategy, "_go_to_page", new_callable=AsyncMock)
+    @patch.object(ProjectFilesDownloadStrategy, "_download_one", new_callable=AsyncMock)
+    @patch.object(ProjectFilesDownloadStrategy, "_row_code", new_callable=AsyncMock)
+    @patch.object(ProjectFilesDownloadStrategy, "_read_total", new_callable=AsyncMock)
+    async def test_respects_limit(self, m_total, m_code, m_one, m_go):
+        m_total.return_value = 370
+        m_code.return_value = "PJ 1"
+        m_one.return_value = True
+        m_go.return_value = True  # more pages always available
+        self.strategy.limit = 3
+
+        result = await self.strategy.download(self.page, self.reports_dir)
+
+        self.assertTrue(result)
+        self.assertEqual(m_one.call_count, 3)
+        m_go.assert_not_called()  # limit hit before advancing pages
+
+    async def test_download_returns_false_when_list_unavailable(self):
+        self.page.goto = AsyncMock(side_effect=Exception("boom"))
+        result = await self.strategy.download(self.page, self.reports_dir)
+        self.assertFalse(result)
+
+    # ---- single project download ----
+
+    async def test_download_one_saves_pdf(self):
+        download = MagicMock()
+        download.suggested_filename = "Projeto.pdf"
+        download.save_as = AsyncMock()
+        self.page.expect_download = MagicMock(return_value=FakeDownloadInfo(download))
+        self.page.locator = MagicMock(return_value=_locator(count=1))
+
+        ok = await self.strategy._download_one(self.page, 0, "PJ 9760", self.reports_dir)
+
+        self.assertTrue(ok)
+        download.save_as.assert_awaited_once()
+        dest = download.save_as.await_args.args[0]
+        self.assertEqual(os.path.basename(dest), "PJ_9760.pdf")
+
+    async def test_download_one_skips_when_no_files(self):
+        self.page.expect_download = MagicMock()
+        self.page.locator = MagicMock(return_value=_locator(count=0))
+
+        ok = await self.strategy._download_one(self.page, 0, "PJ 9999", self.reports_dir)
+
+        self.assertFalse(ok)
+        self.page.expect_download.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Two new capabilities on top of the existing Excel report ETL, all driven by the **single existing login** (the portal rate-limits logins).

### 1. Per-project PDF ETL — `ProjectFilesDownloadStrategy`
- Downloads the **"Projeto"** PDF of every campus project (Diretoria → Projetos → do Campus, `projeto/listaUnidade.aspx`).
- Iterates the paginated grid (370 projects), opens each Resumo modal, saves the file to `reports/project_files/<code>.pdf`. Drafts with no file are skipped fast.
- New CLI: `download-project-files [--limit N]` and `download-everything [--limit N]` (both ETLs, one login).

### 2. Mistral PDF→JSON extraction — `agent_sigpesq.extraction`
- Mistral OCR (`mistral-ocr-latest`) → markdown, then `mistral-large-latest` (JSON mode) fills a pydantic project schema: `titulo, descricao, equipe, coordenador, datas, cronograma, financiamento, objetivos, _meta`.
- Missing fields left `null` and listed in `_meta.campos_ausentes` (never invents data).
- Output: `reports/project_files_json/<code>.json` + combined `projects.json`.
- Optional dep: `pip install -e ".[extract]"` (`mistralai` pinned `<2`).

## Verification
- **PDF ETL:** real run downloaded 5 PDFs; drafts skipped correctly.
- **Extraction:** real run **5/5** projects → high-quality JSON (e.g. PJ_9760: 8 team members, 20 schedule items, R$2M funding across 3 sources, 66 pages).
- **Tests:** 25 passed (mock-based, no browser/network) under the existing pytest CI (Python 3.12).

## Docs
- README: ETL usage, single-login/rate-limit note, extraction section; refreshed **Selenium → Playwright** (actual stack).
- `examples/` with runnable scripts + `examples/README.md`; `.env.example` adds `MISTRAL_KEY`.

## Notes
- Single login is mandatory: the portal returns *"Muitas tentativas. Aguarde alguns segundos."* on rapid re-logins.
- `mistralai` 2.7.0 wheel installs broken (missing top-level package) → pinned `<2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)